### PR TITLE
ngx-kmp-in/out: support null packets

### DIFF
--- a/nginx-common/src/ngx_live_kmp.h
+++ b/nginx-common/src/ngx_live_kmp.h
@@ -53,6 +53,7 @@ enum {
     KMP_PACKET_CONNECT              = 0x74636e63,   /* cnct */
     KMP_PACKET_MEDIA_INFO           = 0x666e696d,   /* minf */
     KMP_PACKET_FRAME                = 0x6d617266,   /* fram */
+    KMP_PACKET_NULL                 = 0x6c6c756e,   /* null */
     KMP_PACKET_END_OF_STREAM        = 0x74736f65,   /* eost */
 
     /* server -> client */

--- a/nginx-kmp-cc-module/src/ngx_stream_kmp_cc_module.c
+++ b/nginx-kmp-cc-module/src/ngx_stream_kmp_cc_module.c
@@ -278,6 +278,13 @@ static ngx_command_t  ngx_stream_kmp_cc_commands[] = {
       offsetof(ngx_stream_kmp_cc_srv_conf_t, out.flush_timeout),
       NULL },
 
+    { ngx_string("kmp_cc_out_keepalive_interval"),
+      NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_STREAM_SRV_CONF_OFFSET,
+      offsetof(ngx_stream_kmp_cc_srv_conf_t, out.keepalive_interval),
+      NULL },
+
     { ngx_string("kmp_cc_out_log_frames"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_flag_slot,
@@ -825,6 +832,10 @@ ngx_stream_kmp_cc_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     if (conf->in_lba == NULL) {
         return NGX_CONF_ERROR;
     }
+
+    /* override the 'no keepalive' default of kmp-out */
+    ngx_conf_merge_msec_value(conf->out.keepalive_interval,
+                              conf->out.keepalive_interval, 10 * 1000);
 
     if (ngx_kmp_out_track_merge_conf(cf, &conf->out, &prev->out) != NGX_OK) {
         return NGX_CONF_ERROR;

--- a/nginx-kmp-in-module/src/ngx_kmp_in.c
+++ b/nginx-kmp-in-module/src/ngx_kmp_in.c
@@ -517,6 +517,7 @@ ngx_kmp_in_process_buffer(ngx_kmp_in_ctx_t *ctx)
             case KMP_PACKET_CONNECT:
             case KMP_PACKET_MEDIA_INFO:
             case KMP_PACKET_FRAME:
+            case KMP_PACKET_NULL:
             case KMP_PACKET_END_OF_STREAM:
                 break;
 
@@ -623,6 +624,10 @@ ngx_kmp_in_process_buffer(ngx_kmp_in_ctx_t *ctx)
 
         case KMP_PACKET_FRAME:
             rc = ngx_kmp_in_frame(ctx);
+            break;
+
+        case KMP_PACKET_NULL:
+            rc = NGX_OK;
             break;
 
         case KMP_PACKET_END_OF_STREAM:

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.h
@@ -32,6 +32,7 @@ typedef struct {
     ngx_lba_t       *lba[KMP_MEDIA_COUNT];
 
     ngx_msec_t       flush_timeout;
+    ngx_msec_t       keepalive_interval;
     ngx_flag_t       log_frames;
 
     time_t           republish_interval;

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track_internal.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track_internal.h
@@ -76,6 +76,7 @@ struct ngx_kmp_out_track_s {
     ngx_buf_queue_t                buf_queue;
     ngx_buf_t                      active_buf;
     ngx_event_t                    flush;
+    ngx_event_t                    keepalive;
 
     kmp_media_info_t               media_info;
     ngx_str_t                      extra_data;

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
@@ -683,6 +683,9 @@ ngx_kmp_out_upstream_ack_packet(ngx_kmp_out_upstream_t *u,
         u->acked_frame_id++;
         break;
 
+    case KMP_PACKET_NULL:
+        break;
+
     case KMP_PACKET_END_OF_STREAM:      /* can happen in case of auto push */
         return NGX_DONE;
 


### PR DESCRIPTION
when publishing subtitles over kmp, there may long periods of time where no subtitle line is being sent. by default, the kmp receiver closes idle connections after 20 sec.
to prevent it from closing the connection, the subtitle sender (e.g. kmp-cc-module) can now send 'null packets' periodically. these packets are ignored by the receiver, and used only for preventing the idle timeout from expiring.
kmp-cc-module now sends null packets every 10 sec by default.