### PR TITLE
ngx-kmp-in/ts/rtmp: open dump file after recv

### DIFF
--- a/nginx-rtmp-module/src/ngx_rtmp.h
+++ b/nginx-rtmp-module/src/ngx_rtmp.h
@@ -283,6 +283,7 @@ typedef struct {
 
     ngx_connection_t       *connection;
     ngx_fd_t                dump_fd;
+    unsigned                dump_input:1;
 
     /* circular buffer of RTMP message pointers */
     ngx_msec_t              timeout;

--- a/nginx-rtmp-module/src/ngx_rtmp_handler.c
+++ b/nginx-rtmp-module/src/ngx_rtmp_handler.c
@@ -291,12 +291,11 @@ ngx_rtmp_recv(ngx_event_t *rev)
                 return;
             }
 
-            if (s->dump_fd != NGX_INVALID_FILE) {
+            if (s->dump_input) {
                 if (ngx_write_fd(s->dump_fd, b->last, n) == NGX_ERROR) {
                     ngx_log_error(NGX_LOG_ERR, s->connection->log, ngx_errno,
                                   "failed to write to rtmp dump file");
-                    ngx_close_file(s->dump_fd);
-                    s->dump_fd = NGX_INVALID_FILE;
+                    s->dump_input = 0;
                 }
             }
 


### PR DESCRIPTION
avoid generating empty files on connections that do not recv any data (can happen due to load balancer tcp health check)