### PR TITLE
ngx-kmp-out: avoid empty send

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track_internal.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track_internal.h
@@ -98,6 +98,7 @@ struct ngx_kmp_out_track_s {
 
     unsigned                       detached:1;
     unsigned                       write_error:1;
+    unsigned                       send_pending:1;
 };
 
 


### PR DESCRIPTION
ngx_kmp_out_track_write_marker_end always calls ngx_kmp_out_track_send_all, but most of the time, no buffer was added to the busy chain of the upstreams.
in ngx_kmp_out_track_write_chain this was already handled by the use of a local 'send' flag.
this change extends this flag also to chunked frame writes.