### PR TITLE
ngx-kmp-cc/ts-kmp/rtmp-kmp: align route defs

### DIFF
--- a/nginx-kmp-cc-module/src/ngx_http_kmp_cc_api_module.c
+++ b/nginx-kmp-cc-module/src/ngx_http_kmp_cc_api_module.c
@@ -10,17 +10,6 @@
 #include "ngx_kmp_cc_version.h"
 
 
-/* routes */
-
-static ngx_int_t ngx_http_kmp_cc_api_get(ngx_http_request_t *r,
-    ngx_str_t *params, ngx_str_t *response);
-
-static ngx_int_t ngx_http_kmp_cc_api_session_delete(ngx_http_request_t *r,
-    ngx_str_t *params, ngx_str_t *response);
-
-#include "ngx_http_kmp_cc_api_routes.h"
-
-
 static ngx_json_str_t  ngx_kmp_cc_version =
     ngx_json_string(NGX_KMP_CC_VERSION);
 static ngx_json_str_t  ngx_kmp_cc_nginx_version =
@@ -130,6 +119,9 @@ ngx_http_kmp_cc_api_session_delete(ngx_http_request_t *r, ngx_str_t *params,
 
     return NGX_OK;
 }
+
+
+#include "ngx_http_kmp_cc_api_routes.h"
 
 
 static ngx_int_t

--- a/nginx-live-module/src/http/ngx_http_live_api_module.c
+++ b/nginx-live-module/src/http/ngx_http_live_api_module.c
@@ -1805,6 +1805,7 @@ ngx_http_live_api_timeline_delete(ngx_http_request_t *r, ngx_str_t *params,
     return NGX_OK;
 }
 
+
 #include "ngx_http_live_api_routes.h"
 
 

--- a/nginx-mpegts-kmp-module/src/ngx_ts_kmp_api_module.c
+++ b/nginx-mpegts-kmp-module/src/ngx_ts_kmp_api_module.c
@@ -16,16 +16,6 @@
 #include "ngx_ts_kmp_track.h"
 
 
-/* routes */
-static ngx_int_t ngx_ts_kmp_api_get(ngx_http_request_t *r, ngx_str_t *params,
-    ngx_str_t *response);
-
-static ngx_int_t ngx_ts_kmp_api_session_delete(ngx_http_request_t *r,
-    ngx_str_t *params, ngx_str_t *response);
-
-#include "ngx_ts_kmp_api_routes.h"
-
-
 static ngx_json_str_t  ngx_ts_kmp_version =
     ngx_json_string(NGX_MPEGTS_KMP_VERSION);
 static ngx_json_str_t  ngx_ts_kmp_nginx_version =
@@ -215,6 +205,9 @@ ngx_ts_kmp_api_session_delete(ngx_http_request_t *r, ngx_str_t *params,
 
     return NGX_OK;
 }
+
+
+#include "ngx_ts_kmp_api_routes.h"
 
 
 static ngx_int_t

--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_api_module.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_api_module.c
@@ -14,14 +14,6 @@
 #include "ngx_kmp_out_upstream.h"
 #include "ngx_rtmp_kmp_version.h"
 
-/* routes */
-static ngx_int_t ngx_rtmp_kmp_api_get(ngx_http_request_t *r, ngx_str_t *params,
-    ngx_str_t *response);
-
-static ngx_int_t ngx_rtmp_kmp_api_session_delete(ngx_http_request_t *r,
-    ngx_str_t *params, ngx_str_t *response);
-
-#include "ngx_rtmp_kmp_api_routes.h"
 
 /* json */
 static size_t ngx_rtmp_kmp_api_streams_json_get_size(ngx_rtmp_session_t *s);
@@ -354,6 +346,9 @@ ngx_rtmp_kmp_api_session_delete(ngx_http_request_t *r, ngx_str_t *params,
 
     return NGX_OK;
 }
+
+
+#include "ngx_rtmp_kmp_api_routes.h"
 
 
 static ngx_int_t


### PR DESCRIPTION
include the route header after the impl of the route handlers, to avoid the need for prototypes