### PR TITLE
nginx build files alignment

### DIFF
--- a/nginx-common/config
+++ b/nginx-common/config
@@ -41,11 +41,10 @@ LIVE_COMMON_DEPS="                                  \
 
 LIVE_COMMON_INCS="$ngx_addon_dir/src"
 
-HTTP_INCS="$HTTP_INCS $ngx_addon_dir/src"
-
 if test -n "$ngx_module_link"; then
-    ngx_module_incs="$LIVE_COMMON_INCS"
     ngx_module_deps="$LIVE_COMMON_DEPS"
+    ngx_module_incs="$LIVE_COMMON_INCS"
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="ngx_http_api_module"
@@ -60,11 +59,11 @@ if test -n "$ngx_module_link"; then
 
         . auto/module
 
+        ngx_module_deps=
+        ngx_module_incs=
 
         ngx_module_type=HTTP
         ngx_module_name=ngx_http_api_module
-        ngx_module_incs=
-        ngx_module_deps=
         ngx_module_srcs=$LIVE_COMMON_HTTP_SRCS
 
         . auto/module
@@ -75,6 +74,8 @@ else
 
     NGX_ADDON_DEPS="$NGX_ADDON_SRCS $LIVE_COMMON_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $LIVE_COMMON_CORE_SRCS $LIVE_COMMON_HTTP_SRCS"
+
+    CFLAGS="$CFLAGS -I$LIVE_COMMON_INCS"
 fi
 
 have=LIVE_COMMON . auto/have

--- a/nginx-kmp-cc-module/config
+++ b/nginx-kmp-cc-module/config
@@ -84,8 +84,9 @@ KMP_CC_DEPS="                                                 \
     "
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir
     ngx_module_deps=$KMP_CC_DEPS
+    ngx_module_incs=
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$KMP_CC_STREAM_MODULES $KMP_CC_HTTP_MODULES"
@@ -99,6 +100,8 @@ if [ -f auto/module ] ; then
         ngx_module_srcs=$KMP_CC_CORE_SRCS
 
         . auto/module
+
+        ngx_module_deps=
 
         ngx_module_type=STREAM
         ngx_module_name=$KMP_CC_STREAM_MODULES
@@ -119,6 +122,4 @@ else
 
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $KMP_CC_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $KMP_CC_CORE_SRCS $KMP_CC_STREAM_SRCS $KMP_CC_HTTP_SRCS"
-
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
 fi

--- a/nginx-kmp-in-module/config
+++ b/nginx-kmp-in-module/config
@@ -30,9 +30,12 @@ KMP_IN_DEPS="                                       \
     $ngx_addon_dir/src/ngx_kmp_in_json.h            \
     "
 
+KMP_IN_INCS="$ngx_addon_dir/src"
+
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir/src
     ngx_module_deps=$KMP_IN_DEPS
+    ngx_module_incs=$KMP_IN_INCS
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="ngx_kmp_in_module"
@@ -54,5 +57,5 @@ else
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $KMP_IN_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $KMP_IN_CORE_SRCS"
 
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
+    CFLAGS="$CFLAGS -I$KMP_IN_INCS"
 fi

--- a/nginx-kmp-out-module/config
+++ b/nginx-kmp-out-module/config
@@ -60,9 +60,12 @@ KMP_OUT_DEPS="                                       \
     $ngx_addon_dir/src/ngx_kmp_out_utils.h           \
     "
 
+KMP_OUT_INCS="$ngx_addon_dir/src"
+
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir/src
     ngx_module_deps=$KMP_OUT_DEPS
+    ngx_module_incs=$KMP_OUT_INCS
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$KMP_OUT_CORE_MODULES $KMP_OUT_HTTP_MODULES"
@@ -76,6 +79,9 @@ if [ -f auto/module ] ; then
         ngx_module_srcs=$KMP_OUT_CORE_SRCS
 
         . auto/module
+
+        ngx_module_deps=
+        ngx_module_incs=
 
         ngx_module_type=HTTP
         ngx_module_name=$KMP_OUT_HTTP_MODULES
@@ -91,5 +97,5 @@ else
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $KMP_OUT_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $KMP_OUT_CORE_SRCS $KMP_OUT_HTTP_SRCS"
 
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
+    CFLAGS="$CFLAGS -I$KMP_OUT_INCS"
 fi

--- a/nginx-kmp-rtmp-module/config
+++ b/nginx-kmp-rtmp-module/config
@@ -68,8 +68,9 @@ KMP_RTMP_DEPS="                                                 \
     "
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir
     ngx_module_deps=$KMP_RTMP_DEPS
+    ngx_module_incs=
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$KMP_RTMP_STREAM_MODULES $KMP_RTMP_HTTP_MODULES"
@@ -83,6 +84,8 @@ if [ -f auto/module ] ; then
         ngx_module_srcs=$KMP_RTMP_CORE_SRCS
 
         . auto/module
+
+        ngx_module_deps=
 
         ngx_module_type=STREAM
         ngx_module_name=$KMP_RTMP_STREAM_MODULES
@@ -103,6 +106,4 @@ else
 
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $KMP_RTMP_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $KMP_RTMP_CORE_SRCS $KMP_RTMP_STREAM_SRCS $KMP_RTMP_HTTP_SRCS"
-
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
 fi

--- a/nginx-live-module/config
+++ b/nginx-live-module/config
@@ -148,8 +148,9 @@ LIVE_DEPS="$LIVE_DEPS                                         \
     "
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir
     ngx_module_deps=$LIVE_DEPS
+    ngx_module_incs=
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$LIVE_CORE_MODULES $LIVE_STREAM_MODULES $LIVE_HTTP_MODULES"
@@ -163,6 +164,8 @@ if [ -f auto/module ] ; then
         ngx_module_srcs=$LIVE_CORE_SRCS
 
         . auto/module
+
+        ngx_module_deps=
 
         ngx_module_type=STREAM
         ngx_module_name=$LIVE_STREAM_MODULES
@@ -184,6 +187,4 @@ else
 
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $LIVE_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $LIVE_CORE_SRCS $LIVE_STREAM_SRCS $LIVE_HTTP_SRCS"
-
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
 fi

--- a/nginx-mpegts-kmp-module/config
+++ b/nginx-mpegts-kmp-module/config
@@ -64,8 +64,9 @@ MPEGTS_KMP_DEPS="                                       \
     "
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir/src
     ngx_module_deps=$MPEGTS_KMP_DEPS
+    ngx_module_incs=
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$MPEGTS_KMP_CORE_MODULES $MPEGTS_KMP_STREAM_MODULES $MPEGTS_KMP_HTTP_MODULES"
@@ -79,6 +80,8 @@ if [ -f auto/module ] ; then
         ngx_module_srcs=$MPEGTS_KMP_CORE_SRCS
 
         . auto/module
+
+        ngx_module_deps=
 
         ngx_module_type=STREAM
         ngx_module_name=$MPEGTS_KMP_STREAM_MODULES
@@ -100,6 +103,4 @@ else
 
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $MPEGTS_KMP_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $MPEGTS_KMP_CORE_SRCS $MPEGTS_KMP_STREAM_SRCS $MPEGTS_KMP_HTTP_SRCS"
-
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
 fi

--- a/nginx-mpegts-module/config
+++ b/nginx-mpegts-module/config
@@ -40,9 +40,12 @@ MPEGTS_DEPS="                                     \
     $ngx_addon_dir/src/ngx_ts_stream.h            \
     "
 
+MPEGTS_INCS="$ngx_addon_dir/src"
+
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir/src
     ngx_module_deps=$MPEGTS_DEPS
+    ngx_module_incs=$MPEGTS_INCS
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$MPEGTS_STREAM_MODULES $MPEGTS_HTTP_MODULES"
@@ -56,6 +59,9 @@ if [ -f auto/module ] ; then
         ngx_module_srcs=$MPEGTS_CORE_SRCS
 
         . auto/module
+
+        ngx_module_deps=
+        ngx_module_incs=
 
         ngx_module_type=STREAM
         ngx_module_name=$MPEGTS_STREAM_MODULES
@@ -77,5 +83,5 @@ else
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $MPEGTS_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $MPEGTS_CORE_SRCS $MPEGTS_STREAM_SRCS $MPEGTS_HTTP_SRCS"
 
-    CFLAGS="$CFLAGS -I$ngx_addon_dir/src"
+    CFLAGS="$CFLAGS -I$MPEGTS_INCS"
 fi

--- a/nginx-pckg-module/config
+++ b/nginx-pckg-module/config
@@ -1,5 +1,7 @@
 ngx_addon_name="ngx_pckg_module"
 
+ngx_module_libs=
+
 # ngx_live_common dependency
 #
 if test -n "$ngx_module_link"; then
@@ -266,8 +268,8 @@ PCKG_DEPS="                                                   \
     "
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir
     ngx_module_deps=$PCKG_DEPS
+    ngx_module_incs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$PCKG_HTTP_MODULES"
@@ -288,6 +290,4 @@ else
 
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $PCKG_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $PCKG_HTTP_SRCS"
-
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
 fi

--- a/nginx-rtmp-kmp-module/config
+++ b/nginx-rtmp-kmp-module/config
@@ -27,6 +27,14 @@ echo "#define NGX_RTMP_KMP_VERSION \""$RTMP_KMP_VERSION"\"" > $NGX_OBJS/ngx_rtmp
 
 # source
 #
+RTMP_KMP_CORE_MODULES="                               \
+    ngx_rtmp_kmp_module                               \
+    "
+
+RTMP_KMP_HTTP_MODULES="                               \
+    ngx_http_rtmp_kmp_api_module                      \
+    "
+
 RTMP_KMP_CORE_SRCS="                                  \
     $ngx_addon_dir/src/ngx_rtmp_kmp_api.c             \
     $ngx_addon_dir/src/ngx_rtmp_kmp_module.c          \
@@ -49,38 +57,36 @@ RTMP_KMP_DEPS="                                       \
     "
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir
     ngx_module_deps=$RTMP_KMP_DEPS
+    ngx_module_incs=
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
-        ngx_module_name="ngx_rtmp_kmp_module ngx_http_rtmp_kmp_api_module"
+        ngx_module_name="$RTMP_KMP_CORE_MODULES $RTMP_KMP_HTTP_MODULES"
         ngx_module_srcs="$RTMP_KMP_CORE_SRCS $RTMP_KMP_HTTP_SRCS"
 
         . auto/module
 
     else
         ngx_module_type=CORE
-        ngx_module_name=ngx_rtmp_kmp_module
+        ngx_module_name=$RTMP_KMP_CORE_MODULES
         ngx_module_srcs=$RTMP_KMP_CORE_SRCS
 
         . auto/module
 
+        ngx_module_deps=
 
         ngx_module_type=HTTP
-        ngx_module_name=ngx_http_rtmp_kmp_api_module
-        ngx_module_incs=
-        ngx_module_deps=
+        ngx_module_name=$RTMP_KMP_HTTP_MODULES
         ngx_module_srcs=$RTMP_KMP_HTTP_SRCS
 
         . auto/module
     fi
 
 else
-    CORE_MODULES="$CORE_MODULES ngx_rtmp_kmp_module"
-    HTTP_MODULES="$HTTP_MODULES ngx_http_rtmp_kmp_api_module"
+    CORE_MODULES="$CORE_MODULES $RTMP_KMP_CORE_MODULES"
+    HTTP_MODULES="$HTTP_MODULES $RTMP_KMP_HTTP_MODULES"
 
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $RTMP_KMP_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $RTMP_KMP_CORE_SRCS $RTMP_KMP_HTTP_SRCS"
-
-    CFLAGS="$CFLAGS -I$ngx_addon_dir"
 fi

--- a/nginx-rtmp-module/config
+++ b/nginx-rtmp-module/config
@@ -45,10 +45,12 @@ RTMP_CORE_SRCS="                                    \
     $ngx_addon_dir/src/ngx_rtmp_proxy_protocol.c    \
     "
 
+RTMP_INCS="$ngx_addon_dir/src"
 
 if [ -f auto/module ] ; then
-    ngx_module_incs=$ngx_addon_dir/src
     ngx_module_deps=$RTMP_DEPS
+    ngx_module_incs=$RTMP_INCS
+    ngx_module_libs=
 
     if [ $ngx_module_link = DYNAMIC ] ; then
         ngx_module_name="$RTMP_CORE_MODULES"
@@ -70,8 +72,7 @@ else
     NGX_ADDON_DEPS="$NGX_ADDON_DEPS $RTMP_DEPS"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $RTMP_CORE_SRCS"
 
-    CFLAGS="$CFLAGS -I$ngx_addon_dir/src"
+    CFLAGS="$CFLAGS -I$RTMP_INCS"
 fi
 
 USE_OPENSSL=YES
-


### PR DESCRIPTION
avoid adding include dir more than once, always go through local vars, reset unused params (e.g. ngx_module_libs) etc.