### PR TITLE
ngx-live: small touchups

### DIFF
--- a/nginx-live-module/src/http/ngx_http_live_api_module.c
+++ b/nginx-live-module/src/http/ngx_http_live_api_module.c
@@ -1684,16 +1684,18 @@ ngx_http_live_api_timeline_get(ngx_http_request_t *r, ngx_str_t *params,
         (ngx_live_json_writer_write_pt) ngx_live_timeline_json_write,
     };
 
-    ngx_int_t             rc;
     ngx_str_t             channel_id;
     ngx_str_t             timeline_id;
     ngx_live_channel_t   *channel;
     ngx_live_timeline_t  *timeline;
 
     channel_id = params[0];
-    rc = ngx_http_live_api_channel_get_unblocked(r, &channel_id, &channel);
-    if (rc != NGX_OK) {
-        return rc;
+    channel = ngx_live_channel_get(&channel_id);
+    if (channel == NULL) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "ngx_http_live_api_timeline_get: unknown channel \"%V\"",
+            &channel_id);
+        return NGX_HTTP_NOT_FOUND;
     }
 
     timeline_id = params[1];

--- a/nginx-live-module/src/ngx_live_input_bufs.c
+++ b/nginx-live-module/src/ngx_live_input_bufs.c
@@ -76,7 +76,7 @@ static ngx_command_t  ngx_live_input_bufs_commands[] = {
 
     { ngx_string("input_bufs_bin_count"),
       NGX_LIVE_MAIN_CONF|NGX_LIVE_PRESET_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_size_slot,
+      ngx_conf_set_num_slot,
       NGX_LIVE_PRESET_CONF_OFFSET,
       offsetof(ngx_live_input_bufs_preset_conf_t, bin_count),
       NULL },
@@ -617,7 +617,7 @@ ngx_live_input_bufs_global_json_write(u_char *p, void *obj)
         cur = ngx_queue_data(q, ngx_live_input_bufs_t, queue);
 
         buf_queue = &cur->buf_queue;
-        size += buf_queue->nbuffers * buf_queue->alloc_size;
+        size += ngx_buf_queue_mem_used(buf_queue);
         lock_count += cur->lock_count;
         count++;
     }
@@ -658,7 +658,7 @@ ngx_live_input_bufs_track_json_write(u_char *p, void *obj)
     ctx = ngx_live_get_module_ctx(track, ngx_live_input_bufs_module);
 
     buf_queue = &ctx->input_bufs->buf_queue;
-    size = buf_queue->nbuffers * buf_queue->alloc_size;
+    size = ngx_buf_queue_mem_used(buf_queue);
 
     p = ngx_copy_fix(p, "\"input_bufs\":{\"size\":");
     p = ngx_sprintf(p, "%uz", size);

--- a/nginx-live-module/src/ngx_live_segment_cache.h
+++ b/nginx-live-module/src/ngx_live_segment_cache.h
@@ -8,9 +8,6 @@
 #include "ngx_live.h"
 
 
-#define NGX_LIVE_READ_FLAG_LOCK_DATA  (0x01)
-
-
 struct ngx_live_segment_s {
     ngx_rbtree_node_t         node;
     ngx_queue_t               queue;


### PR DESCRIPTION
- api: allow timeline.get on blocked channels
- input bufs: use the mem_used macro instead of nbuffers * size
- segment cache: remove unneeded constant