### PR TITLE
ngx-kmp-out: change auto_ack to resume_from enum

### DIFF
--- a/conf/controller.php
+++ b/conf/controller.php
@@ -192,6 +192,7 @@ function getCCDecodeUpstream($segmenterKmpUrl, $channelId, $ccConf)
     $upstream = array(
         'id' => 'cc-vid',
         'url' => $ccDecoderUrl,
+        'resume_from' => 'last_sent',
     );
 
     if ($ccConf)

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
@@ -10,51 +10,57 @@
 #include <ngx_http_call.h>
 
 
+typedef enum {
+    ngx_kmp_out_resume_from_last_acked,
+    ngx_kmp_out_resume_from_last_sent,
+} ngx_kmp_out_resume_from_e;
+
+
 typedef struct {
-    ngx_peer_connection_t      peer;
-    u_char                     sockaddr_buf[NGX_SOCKADDRLEN];
+    ngx_peer_connection_t        peer;
+    u_char                       sockaddr_buf[NGX_SOCKADDRLEN];
 
-    u_char                     remote_addr_buf[NGX_SOCKADDR_STRLEN];
-    ngx_json_str_t             remote_addr;
+    u_char                       remote_addr_buf[NGX_SOCKADDR_STRLEN];
+    ngx_json_str_t               remote_addr;
 
-    u_char                     local_addr_buf[NGX_SOCKADDR_STRLEN];
-    ngx_json_str_t             local_addr;
+    u_char                       local_addr_buf[NGX_SOCKADDR_STRLEN];
+    ngx_json_str_t               local_addr;
 
-    ngx_json_str_t             id;
-    ngx_queue_t                queue;
-    ngx_kmp_out_track_t       *track;
+    ngx_json_str_t               id;
+    ngx_queue_t                  queue;
+    ngx_kmp_out_track_t         *track;
 
-    ngx_log_t                  log;
-    ngx_pool_t                *pool;
-    ngx_msec_t                 timeout;
+    ngx_log_t                    log;
+    ngx_pool_t                  *pool;
+    ngx_msec_t                   timeout;
 
-    ngx_http_call_ctx_t       *republish_call;
-    ngx_event_t                republish;
-    time_t                     republish_time;
-    ngx_uint_t                 republishes;
+    ngx_http_call_ctx_t         *republish_call;
+    ngx_event_t                  republish;
+    time_t                       republish_time;
+    ngx_uint_t                   republishes;
 
-    ngx_chain_t              **last;
-    ngx_chain_t               *free;
-    ngx_chain_t               *busy;
+    ngx_chain_t                **last;
+    ngx_chain_t                 *free;
+    ngx_chain_t                 *busy;
 
-    kmp_connect_packet_t       connect;
-    ngx_buf_t                  connect_data;
+    kmp_connect_packet_t         connect;
+    ngx_buf_t                    connect_data;
 
-    kmp_ack_frames_packet_t    ack_frames;
-    u_char                    *recv_pos;
+    kmp_ack_frames_packet_t      ack_frames;
+    u_char                      *recv_pos;
 
-    ngx_buf_queue_stream_t     acked_reader;
-    uint64_t                   acked_frame_id;
-    uint64_t                   acked_upstream_frame_id;
-    uint32_t                   acked_offset;
-    ngx_buf_t                  acked_media_info;
-    off_t                      acked_bytes;
-    off_t                      sent_base;
-    ngx_uint_t                 auto_acked_frames;
+    ngx_buf_queue_stream_t       acked_reader;
+    uint64_t                     acked_frame_id;
+    uint64_t                     acked_upstream_frame_id;
+    uint32_t                     acked_offset;
+    ngx_buf_t                    acked_media_info;
+    off_t                        acked_bytes;
+    off_t                        sent_base;
+    ngx_uint_t                   auto_acked_frames;
+    ngx_kmp_out_resume_from_e    resume_from;
 
-    unsigned                   sent_end:1;
-    unsigned                   auto_ack:1;
-    unsigned                   no_republish:1;
+    unsigned                     sent_end:1;
+    unsigned                     no_republish:1;
 } ngx_kmp_out_upstream_t;
 
 

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream_json.txt
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream_json.txt
@@ -2,7 +2,7 @@
 in ngx_kmp_out_upstream_json
     url %V
     id %V
-    auto_ack %b
+    resume_from %enum-ngx_kmp_out_resume_from_names
     connect_data %V
 
 out noobject ngx_kmp_out_upstream_republish_json ngx_kmp_out_upstream_t
@@ -17,7 +17,7 @@ out nostatic ngx_kmp_out_upstream_json ngx_kmp_out_upstream_t
     remote_addr %jV
     local_addr %jV
     connection %uA obj->log.
-    auto_ack %b
+    resume_from %enum-ngx_kmp_out_resume_from_names
 
     sent_bytes %O (obj->peer.connection ? obj->peer.connection->sent : 0)
     position %O (obj->peer.connection ? obj->sent_base + obj->peer.connection->sent : 0)


### PR DESCRIPTION
in preparation for adding an option to start sending from the last frame that was written.