### PR TITLE
ngx-live/pckg: fix rendition report handling

### DIFF
--- a/nginx-common/src/ngx_ksmp.h
+++ b/nginx-common/src/ngx_ksmp.h
@@ -222,6 +222,8 @@ typedef struct {
 
 typedef struct {
     uint32_t                     count;
+    uint32_t                     last_sequence;
+    uint32_t                     last_part_index;
 } ngx_ksmp_rendition_reports_header_t;
 
 

--- a/nginx-pckg-module/src/ngx_pckg_ksmp.c
+++ b/nginx-pckg-module/src/ngx_pckg_ksmp.c
@@ -771,6 +771,9 @@ ngx_pckg_ksmp_read_rendition_reports(ngx_persist_block_hdr_t *header,
         return NGX_BAD_DATA;
     }
 
+    channel->rr_last_sequence = h.last_sequence;
+    channel->rr_last_part_index = h.last_part_index;
+
     return NGX_OK;
 }
 

--- a/nginx-pckg-module/src/ngx_pckg_ksmp.h
+++ b/nginx-pckg-module/src/ngx_pckg_ksmp.h
@@ -196,11 +196,14 @@ struct ngx_pckg_channel_s {
     ngx_pckg_timeline_t            timeline;
     ngx_array_t                    variants;  /* ngx_pckg_variant_t */
     ngx_array_t                    tracks;    /* ngx_pckg_track_t */
-    ngx_array_t                    rrs;       /* ngx_pckg_rendition_report_t */
     ngx_array_t                    css;       /* ngx_pckg_captions_service_t */
     ngx_ksmp_segment_index_t      *segment_index;
     ngx_pckg_dynamic_vars_t        vars;
     uint32_t                       media_types;
+
+    ngx_array_t                    rrs;       /* ngx_pckg_rendition_report_t */
+    uint32_t                       rr_last_sequence;
+    uint32_t                       rr_last_part_index;
 
     uint32_t                       err_code;
     ngx_str_t                      err_msg;


### PR DESCRIPTION
according to spec when the msn/last-part of a rendition report matches the current track, the specific property may be omitted, the rendition report tag should remain.