### PR TITLE
ngx-kmp-out: last_written bug fix

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -1225,6 +1225,7 @@ ngx_kmp_out_track_update_frame_stats(ngx_kmp_out_track_stats_t *stats,
     }
 
     stats->last_created = frame->f.created;
+    stats->last_frame_written = stats->written;
 
     if (ngx_cached_time->sec < stats->period_end) {
         return;

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track_internal.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track_internal.h
@@ -39,6 +39,8 @@ typedef struct {
 
 typedef struct {
     size_t                         written;
+    size_t                         last_frame_written;
+
     int64_t                        last_timestamp;
     int64_t                        last_created;
     ngx_uint_t                     sent_frames;

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
@@ -783,7 +783,7 @@ ngx_kmp_out_upstream_auto_ack(ngx_kmp_out_upstream_t *u, size_t left)
         limit = u->sent_base + u->peer.connection->sent;
 
     } else {
-        limit = u->track->stats.written;
+        limit = u->track->stats.last_frame_written;
     }
 
     for (count = 0; ; count++) {


### PR DESCRIPTION
when the frames that are written to the kmp-out-track are written in parts (=using the frame_start / frame_end funcs), append is called before the frame header was written (frame_start writes a zero frame header, and frame_end updates it)
the 'written' value of the track includes the partial frame data that was already written, so ngx_kmp_out_upstream_auto_ack tries to parse it. however, since the frame header is zero, ngx_kmp_out_upstream_ack_packet sees packet_type = 0 and fails.
the solution is to keep the 'written' value when the last frame ended, and auto ack frames up to this value. this way, the header of the partial frame will not be read, and no error will occur.