### PR TITLE
ngx-kmp-out: protect against slow upstream

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -1003,7 +1003,7 @@ ngx_kmp_out_track_mem_watermark(ngx_kmp_out_track_t *track)
         }
 
         rc = ngx_kmp_out_upstream_auto_ack(u,
-            track->mem_low_watermark - track->mem_left);
+            track->mem_low_watermark - track->mem_left, 1);
         if (rc <= 0) {
             return rc;
         }

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
@@ -79,7 +79,7 @@ ngx_int_t ngx_kmp_out_upstream_append_buffer(ngx_kmp_out_upstream_t *u,
     ngx_buf_t *buffer);
 
 ngx_int_t ngx_kmp_out_upstream_auto_ack(ngx_kmp_out_upstream_t *u,
-    size_t left);
+    size_t left, ngx_flag_t force);
 
 void ngx_kmp_out_upstream_free(ngx_kmp_out_upstream_t *u);
 


### PR DESCRIPTION
when the kmp-out-upstream is connected, the auto ack is limited by the number of sent bytes. if the upstream server is receiving very slowly, this may prevent the "watermark" mechanism from freeing buffers. eventually, the memory limit will be hit, and the client rtmp/mpegts connection will be dropped.
note that if the upstream is not receiving at all, the write timeout will kill the connection, the memory limit may be hit only if the upstream server is receiving, but slowly.
the solution is to perform a republish in this case, the republish closes the upstream connection, making it possible to acknowledge packets that were not sent yet.