### PR TITLE
ngx-kmp-out: republish fixes

### DIFF
--- a/nginx-kmp-cc-module/src/ngx_stream_kmp_cc_module.c
+++ b/nginx-kmp-cc-module/src/ngx_stream_kmp_cc_module.c
@@ -294,7 +294,7 @@ static ngx_command_t  ngx_stream_kmp_cc_commands[] = {
 
     { ngx_string("kmp_cc_out_republish_interval"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_sec_slot,
+      ngx_conf_set_msec_slot,
       NGX_STREAM_SRV_CONF_OFFSET,
       offsetof(ngx_stream_kmp_cc_srv_conf_t, out.republish_interval),
       NULL },

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -128,7 +128,7 @@ ngx_kmp_out_track_init_conf(ngx_kmp_out_track_conf_t *conf)
         conf->mem_limit[media_type] = NGX_CONF_UNSET_SIZE;
     }
 
-    conf->republish_interval = NGX_CONF_UNSET;
+    conf->republish_interval = NGX_CONF_UNSET_MSEC;
     conf->max_republishes = NGX_CONF_UNSET_UINT;
 }
 
@@ -201,11 +201,11 @@ ngx_kmp_out_track_merge_conf(ngx_conf_t *cf, ngx_kmp_out_track_conf_t *conf,
     ngx_conf_merge_uint_value(conf->log_frames, prev->log_frames,
                               NGX_KMP_OUT_LOG_FRAMES_OFF);
 
-    ngx_conf_merge_value(conf->republish_interval,
-                         prev->republish_interval, 1);
+    ngx_conf_merge_msec_value(conf->republish_interval,
+                              prev->republish_interval, 1000);
 
     ngx_conf_merge_uint_value(conf->max_republishes,
-                              prev->max_republishes, 10);
+                              prev->max_republishes, 15);
 
     for (media_type = 0; media_type < KMP_MEDIA_COUNT; media_type++) {
         conf->lba[media_type] = ngx_lba_get_global(cf,

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.h
@@ -35,7 +35,7 @@ typedef struct {
     ngx_msec_t       keepalive_interval;
     ngx_uint_t       log_frames;
 
-    time_t           republish_interval;
+    ngx_msec_t       republish_interval;
     ngx_uint_t       max_republishes;
 } ngx_kmp_out_track_conf_t;
 

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
@@ -37,7 +37,7 @@ typedef struct {
 
     ngx_http_call_ctx_t         *republish_call;
     ngx_event_t                  republish;
-    time_t                       republish_time;
+    ngx_msec_t                   republish_time;
     ngx_uint_t                   republishes;
 
     ngx_chain_t                **last;

--- a/nginx-mpegts-kmp-module/src/ngx_http_ts_kmp_module.c
+++ b/nginx-mpegts-kmp-module/src/ngx_http_ts_kmp_module.c
@@ -192,7 +192,7 @@ static ngx_command_t  ngx_http_ts_kmp_commands[] = {
 
     { ngx_string("ts_kmp_republish_interval"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_sec_slot,
+      ngx_conf_set_msec_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_ts_kmp_loc_conf_t, kmp.t.republish_interval),
       NULL },

--- a/nginx-mpegts-kmp-module/src/ngx_stream_ts_kmp_module.c
+++ b/nginx-mpegts-kmp-module/src/ngx_stream_ts_kmp_module.c
@@ -192,7 +192,7 @@ static ngx_command_t  ngx_stream_ts_kmp_commands[] = {
 
     { ngx_string("ts_kmp_republish_interval"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_sec_slot,
+      ngx_conf_set_msec_slot,
       NGX_STREAM_SRV_CONF_OFFSET,
       offsetof(ngx_stream_ts_kmp_srv_conf_t, kmp.t.republish_interval),
       NULL },

--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_module.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_module.c
@@ -231,7 +231,7 @@ static ngx_command_t  ngx_rtmp_kmp_commands[] = {
 
     { ngx_string("kmp_republish_interval"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
-      ngx_conf_set_sec_slot,
+      ngx_conf_set_msec_slot,
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_kmp_app_conf_t, t.republish_interval),
       NULL },


### PR DESCRIPTION
1. use ngx_current_msec for the republish delay instead of ngx_time, for more accurate timing of republish requests
2. if the connection with the upstream was not established at all, ngx_kmp_out_upstream_republish would incorrectly assume there is nothing to send (u->busy is null). need to check also u->last (u->busy is always null when u->last is null)
3. due to the previous item, the republishes counter may have not counted some republish attempts, increase the default limit to 15 as a safety measure