### PR TITLE
ngx-rtmp: disable play functionality

### DIFF
--- a/nginx-rtmp-module/README.md
+++ b/nginx-rtmp-module/README.md
@@ -193,38 +193,6 @@ A higher number increases memory usage, but enables faster lookup of stream by n
 
 When set to non-zero, output messages are buffered in queue, until the number of buffers reaches the value set in `out_cork`.
 
-#### sync
-* **syntax**: `sync msec;`
-* **default**: `300ms`
-* **context**: `rtmp`, `server`, `application`
-
-When set to a non-zero value, if the duration of dropped packets exceeds the configured value, the stream is resynched.
-This parameter is not relevant in the context of Media-Framework.
-
-#### interleave
-* **syntax**: `interleave on | off;`
-* **default**: `off`
-* **context**: `rtmp`, `server`, `application`
-
-When enabled, audio and video data is transmitted on the same RTMP chunk stream.
-This parameter is not relevant in the context of Media-Framework.
-
-#### wait_key
-* **syntax**: `wait_key on | off;`
-* **default**: `off`
-* **context**: `rtmp`, `server`, `application`
-
-Makes video streams start with a key frame.
-This parameter is not relevant in the context of Media-Framework.
-
-#### wait_video
-* **syntax**: `wait_video on | off;`
-* **default**: `off`
-* **context**: `rtmp`, `server`, `application`
-
-Disable audio until first video frame is sent. Can be combined with wait_key to make client receive video key frame with all other data following it.
-This parameter is not relevant in the context of Media-Framework.
-
 #### publish_notify
 * **syntax**: `publish_notify on | off;`
 * **default**: `off`

--- a/nginx-rtmp-module/src/ngx_rtmp_live_module.c
+++ b/nginx-rtmp-module/src/ngx_rtmp_live_module.c
@@ -59,6 +59,7 @@ static ngx_command_t  ngx_rtmp_live_commands[] = {
       offsetof(ngx_rtmp_live_app_conf_t, buflen),
       NULL },
 
+#if 0
     { ngx_string("sync"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
       ngx_rtmp_live_set_msec_slot,
@@ -86,6 +87,7 @@ static ngx_command_t  ngx_rtmp_live_commands[] = {
       NGX_RTMP_APP_CONF_OFFSET,
       offsetof(ngx_rtmp_live_app_conf_t, wait_video),
       NULL },
+#endif
 
     { ngx_string("publish_notify"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
@@ -728,12 +730,16 @@ next:
 static ngx_int_t
 ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h, ngx_chain_t *in)
 {
+    ngx_uint_t                      peers;
+    ngx_rtmp_live_ctx_t            *ctx;
+    ngx_rtmp_live_app_conf_t       *lacf;
+
+#if 0
     ngx_rtmp_live_ctx_t            *ctx, *pctx;
     ngx_rtmp_codec_ctx_t           *codec_ctx;
     ngx_chain_t                    *header, *coheader, *meta,
                                    *apkt, *aapkt, *acopkt, *rpkt;
     ngx_rtmp_core_srv_conf_t       *cscf;
-    ngx_rtmp_live_app_conf_t       *lacf;
     ngx_rtmp_session_t             *ss;
     ngx_rtmp_header_t               ch, lh, clh;
     ngx_int_t                       rc, mandatory, dummy_audio;
@@ -743,6 +749,8 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h, ngx_chain_t *in)
     ngx_uint_t                      csidx;
     uint32_t                        delta;
     ngx_rtmp_live_chunk_stream_t   *cs;
+#endif
+
 #ifdef NGX_DEBUG
     const char                     *type_s;
 
@@ -791,6 +799,9 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h, ngx_chain_t *in)
         goto done;
     }
 
+    return NGX_ERROR;
+
+#if 0
     apkt = NULL;
     aapkt = NULL;
     acopkt = NULL;
@@ -1066,6 +1077,8 @@ ngx_rtmp_live_av(ngx_rtmp_session_t *s, ngx_rtmp_header_t *h, ngx_chain_t *in)
         ngx_rtmp_free_shared_chain(cscf, acopkt);
     }
 
+#endif
+
 done:
 
     ngx_rtmp_update_bandwidth(&ctx->stream->bw_in, h->mlen);
@@ -1128,6 +1141,9 @@ next:
 static ngx_int_t
 ngx_rtmp_live_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 {
+    return NGX_ERROR;
+
+#if 0
     ngx_rtmp_live_app_conf_t       *lacf;
     ngx_rtmp_live_ctx_t            *ctx;
     u_char                          name[2 * sizeof(void *) + 1];
@@ -1169,6 +1185,7 @@ ngx_rtmp_live_play(ngx_rtmp_session_t *s, ngx_rtmp_play_t *v)
 next:
 
     return next_play(s, v);
+#endif
 }
 
 


### PR DESCRIPTION
- return error in 'play' callback
- return error in case a publisher needs to send data to subscribers
- remove conf directives that are no longer relevant