### PR TITLE
ngx-rtmp: fix sps nal check

### DIFF
--- a/nginx-rtmp-module/src/ngx_rtmp_codec_module.c
+++ b/nginx-rtmp-module/src/ngx_rtmp_codec_module.c
@@ -619,7 +619,7 @@ ngx_rtmp_codec_parse_avc_header(ngx_rtmp_session_t *s, ngx_chain_t *in)
     ngx_rtmp_bit_read(&br, 16);
 
     /* nal type */
-    if (ngx_rtmp_bit_read_8(&br) != 0x67) {
+    if ((ngx_rtmp_bit_read_8(&br) & 0x1f) != 7) {
         return;
     }
 


### PR DESCRIPTION
doesn't have to be 0x67, can also be 0x27.
need to extract the nal type using & 0x1f, and compare to 7.