### PR TITLE
ngx-kmp-out: add required flag to upstream

### DIFF
--- a/conf/controller.php
+++ b/conf/controller.php
@@ -334,9 +334,17 @@ case 'republish':
     $channelId = $params['channel_id'];
 
     // TODO: handle republish for transcoded streams
-    $upstream = $upstreamId == 'cc' ?
-        getCCDecodeUpstream($segmenterKmpUrl, $channelId, $ccConf) :
-        array('url' => $segmenterKmpUrl);
+    switch ($upstreamId)
+    {
+    case 'cc':
+        $upstream = getCCDecodeUpstream($segmenterKmpUrl, $channelId, $ccConf);
+        break;
+
+    default:
+        $upstream = array('url' => $segmenterKmpUrl);
+        break;
+    }
+
     outputJson($upstream);
     break;
 

--- a/nginx-kmp-out-module/README.md
+++ b/nginx-kmp-out-module/README.md
@@ -78,6 +78,9 @@ For example, when used with nginx-mpegts-kmp-module, the `rtmp` block is replace
 - `upstreams` - required, array of objects, each object can contain the following fields:
     - `url` - required, string, must include ip address and port (hostname is not supported), can optionally be prefixed with `kmp://`
     - `id` - optional, string, used for identifying the upstream in `republish` requests and in the management API
+    - `required` - optional, boolean, when set to `true`, an error in the upstream frees the output track, and the input connection associated with it.
+        When set to `false`, an error in the upstream is ignored, unless the upstream is the last upstream on the output track.
+        The default value is `true`.
     - `resume_from` - optional, string, sets the offset from which the module starts sending frames, if the upstream connection is re-established.
         The following values are defined:
         - `last_acked` - the frame after the last frame that was explicitly acked (this is the default)
@@ -204,6 +207,7 @@ The sections below list the possible fields in each type of API object.
 - `remote_addr` - string, the ip + port of the remote peer
 - `local_addr` - string, the local ip + port of the connection
 - `connection` - integer, the nginx connection identifier, unique per nginx worker process
+- `required` - boolean, the `required` setting that was configured when the upstream was created
 - `resume_from` - string, the `resume_from` setting that was configured when the upstream was created
 - `sent_bytes` - integer, the number of bytes that were sent since the connection was established (gets reset if the connection is dropped)
 - `position` - integer, the position of the upstream in the send queue of the track. Can be used, for example, to compare different upstreams on the same track, in order to detect upstreams that are lagging
@@ -290,6 +294,9 @@ The request body must be a JSON object, with the following fields:
 - `url` - required, string, must include ip address and port (hostname is not supported), can optionally be prefixed with `kmp://`
 - `id` - optional, string, used for identifying the upstream in `republish` requests and in the API
 - `src_id` - optional, string, if supplied, must contain the id of an existing upstream on the track to copy from
+- `required` - optional, boolean, when set to `true`, an error in the upstream frees the output track, and the input connection associated with it.
+    When set to `false`, an error in the upstream is ignored, unless the upstream is the last upstream on the output track.
+    The default value is `true`.
 - `resume_from` - optional, string, sets the offset from which the module starts sending frames, if the upstream connection is re-established.
     The following values are defined:
     - `last_acked` - the frame after the last frame that was explicitly acked (this is the default)

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
@@ -363,9 +363,16 @@ ngx_kmp_out_upstream_free(ngx_kmp_out_upstream_t *u)
 static void
 ngx_kmp_out_upstream_free_notify(ngx_kmp_out_upstream_t *u)
 {
+    ngx_flag_t            required;
     ngx_kmp_out_track_t  *track = u->track;
 
+    required = u->required;
+
     ngx_kmp_out_upstream_free(u);
+
+    if (!required && !ngx_queue_empty(&track->upstreams)) {
+        return;
+    }
 
     ngx_kmp_out_track_error(track, "upstream_error");
 }
@@ -425,6 +432,7 @@ ngx_kmp_out_upstream_from_json(ngx_pool_t *temp_pool,
         return NGX_ABORT;
     }
 
+    u->required = json.required != 0;   /* enabled by default */
     ngx_json_set_uint_value(u->resume_from, json.resume_from);
 
     return NGX_OK;

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.h
@@ -60,6 +60,7 @@ typedef struct {
     ngx_uint_t                   auto_acked_frames;
     ngx_kmp_out_resume_from_e    resume_from;
 
+    unsigned                     required:1;
     unsigned                     sent_end:1;
     unsigned                     no_republish:1;
 } ngx_kmp_out_upstream_t;

--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream_json.txt
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream_json.txt
@@ -2,6 +2,7 @@
 in ngx_kmp_out_upstream_json
     url %V
     id %V
+    required %b
     resume_from %enum-ngx_kmp_out_resume_from_names
     connect_data %V
 
@@ -17,6 +18,7 @@ out nostatic ngx_kmp_out_upstream_json ngx_kmp_out_upstream_t
     remote_addr %jV
     local_addr %jV
     connection %uA obj->log.
+    required %b
     resume_from %enum-ngx_kmp_out_resume_from_names
 
     sent_bytes %O (obj->peer.connection ? obj->peer.connection->sent : 0)


### PR DESCRIPTION
when set to false, upstream errors are ignored, unless the upstream is the last on the output track