### PR TITLE
ngx-common: add validation on json writes

### DIFF
--- a/nginx-common/test/validate_json_write.py
+++ b/nginx-common/test/validate_json_write.py
@@ -1,0 +1,35 @@
+import sys
+import re
+import os
+
+def get_quoted_str(s):
+    start = s.find('"')
+    if start < 0:
+        return None
+
+    end = s.rfind('"')
+    s = s[(start + 1):end]
+
+    return re.sub(r'(?<!\\)"\s+"', '', s)
+
+def process_file(file_path):
+    file_data = open(file_path, 'r').read()
+
+    sizeofs = set(map(get_quoted_str, re.findall('sizeof\(([^)]*)\)', file_data)))
+    copies = set(map(get_quoted_str, re.findall('ngx_copy_fix\(([^)]*)\)', file_data)))
+    
+    missing_sizeof = copies - sizeofs - set(["true"])
+    for s in missing_sizeof:
+        print('Error: missing sizeof for %s in %s' % (s, file_path))
+
+
+root_folder = os.path.join(os.path.dirname(__file__), '../..')
+root_folder = os.path.normpath(root_folder)
+
+for root, _, files in os.walk(root_folder):
+    for name in files:
+        if os.path.splitext(name)[1] not in ['.c', '.h']:
+            continue
+
+        file_path = os.path.join(root, name)
+        process_file(file_path)

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -239,7 +239,7 @@ ngx_kmp_out_track_media_info_json_get_size(ngx_kmp_out_track_t *track)
 {
     size_t  size;
 
-    size = sizeof("\"media_info\":{}") - 1;
+    size = sizeof("\"media_info\":{") - 1 + sizeof("}") - 1;
 
     switch (track->media_info.media_type) {
 

--- a/nginx-live-module/src/ngx_live_media_info.c
+++ b/nginx-live-module/src/ngx_live_media_info.c
@@ -1628,16 +1628,18 @@ ngx_live_media_info_track_json_get_size(void *obj)
         ngx_json_str_get_size(&ctx->group_id) +
         sizeof("\",\"gap_fill_dest\":") - 1 + NGX_INT32_LEN +
         sizeof(",\"gap_fill_source\":") - 1 + NGX_INT32_LEN +
-        sizeof(",\"media_info\":{\"added\":,\"removed\":}") - 1 +
-        2 * NGX_INT32_LEN;
+        sizeof(",\"media_info\":{\"added\":") - 1 + NGX_INT32_LEN +
+        sizeof(",\"removed\":") - 1 + NGX_INT32_LEN +
+        sizeof("}") - 1;
 
     if (ngx_queue_empty(&ctx->active)) {
         return result;
     }
 
     if (ctx->source) {
-        result += sizeof(",\"source\":\"\"") - 1 +
-            ctx->source->sn.str.len + ctx->source->id_escape;
+        result += sizeof(",\"source\":\"") - 1
+            + ctx->source->sn.str.len + ctx->source->id_escape
+            + sizeof("\"") - 1;
     }
 
     q = ngx_queue_last(&ctx->active);

--- a/nginx-pckg-module/src/ngx_http_pckg_mpd.c
+++ b/nginx-pckg-module/src/ngx_http_pckg_mpd.c
@@ -773,7 +773,7 @@ ngx_http_pckg_mpd_init_cea_params(ngx_pckg_channel_t *channel,
         case 8:
         case 9:
             /* service1 - service63 */
-            if (c7_end - c7_p < 12) {
+            if (c7_end - c7_p < 6 + (ssize_t) sizeof("=lang:") - 1) {
                 ngx_log_error(NGX_LOG_WARN, channel->log, 0,
                     "ngx_http_pckg_mpd_init_cea_params: "
                     "708 value overflow");


### PR DESCRIPTION
code generated by generate_json_header.py is guaranteed to be consistent between the 'write' func and the 'get_size' func.
however, hand-written code may get out of sync.
the script collects all strings written using ngx_copy_fix, and makes sure the code contains a matching sizeof.