### PR TITLE
ngx-kmp-in: skip subtitle frames with pts_delay<=0

### DIFF
--- a/nginx-kmp-in-module/src/ngx_kmp_in.c
+++ b/nginx-kmp-in-module/src/ngx_kmp_in.c
@@ -406,6 +406,13 @@ ngx_kmp_in_frame(ngx_kmp_in_ctx_t *ctx)
         goto done;
     }
 
+    if (ctx->media_type == KMP_MEDIA_SUBTITLE && frame->pts_delay <= 0) {
+        ngx_log_error(NGX_LOG_WARN, ctx->log, 0,
+            "ngx_kmp_in_frame: skipping subtitle frame with empty duration");
+        ctx->skipped.empty_duration++;
+        goto done;
+    }
+
     if (ctx->wait_key) {
 
         /* ignore frames that arrive before the first key */

--- a/nginx-kmp-in-module/src/ngx_kmp_in.h
+++ b/nginx-kmp-in-module/src/ngx_kmp_in.h
@@ -25,6 +25,7 @@ typedef struct {
 typedef struct {
     ngx_uint_t             duplicate;
     ngx_uint_t             empty;
+    ngx_uint_t             empty_duration;
     ngx_uint_t             no_media_info;
     ngx_uint_t             no_key;
 } ngx_kmp_in_stats_skip_t;

--- a/nginx-kmp-in-module/src/ngx_kmp_in_json.h
+++ b/nginx-kmp-in-module/src/ngx_kmp_in_json.h
@@ -59,6 +59,7 @@ ngx_kmp_in_stats_skip_json_get_size(ngx_kmp_in_stats_skip_t *obj)
     result =
         sizeof("{\"duplicate\":") - 1 + NGX_INT_T_LEN +
         sizeof(",\"empty\":") - 1 + NGX_INT_T_LEN +
+        sizeof(",\"empty_duration\":") - 1 + NGX_INT_T_LEN +
         sizeof(",\"no_media_info\":") - 1 + NGX_INT_T_LEN +
         sizeof(",\"no_key\":") - 1 + NGX_INT_T_LEN +
         sizeof("}") - 1;
@@ -74,6 +75,8 @@ ngx_kmp_in_stats_skip_json_write(u_char *p, ngx_kmp_in_stats_skip_t *obj)
     p = ngx_sprintf(p, "%ui", (ngx_uint_t) obj->duplicate);
     p = ngx_copy_fix(p, ",\"empty\":");
     p = ngx_sprintf(p, "%ui", (ngx_uint_t) obj->empty);
+    p = ngx_copy_fix(p, ",\"empty_duration\":");
+    p = ngx_sprintf(p, "%ui", (ngx_uint_t) obj->empty_duration);
     p = ngx_copy_fix(p, ",\"no_media_info\":");
     p = ngx_sprintf(p, "%ui", (ngx_uint_t) obj->no_media_info);
     p = ngx_copy_fix(p, ",\"no_key\":");

--- a/nginx-kmp-in-module/src/ngx_kmp_in_json.txt
+++ b/nginx-kmp-in-module/src/ngx_kmp_in_json.txt
@@ -8,6 +8,7 @@ out nostatic ngx_kmp_in_stats_latency_json ngx_kmp_in_stats_latency_t
 out ngx_kmp_in_stats_skip_json ngx_kmp_in_stats_skip_t
     duplicate %ui
     empty %ui
+    empty_duration %ui
     no_media_info %ui
     no_key %ui
 


### PR DESCRIPTION
in subtitle frames, the pts_delay holds the duration of the cue, a negative pts_delay is meaningless