### PR TITLE
ngx-kmp-out: fix empty upstreams array in publish

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -348,7 +348,7 @@ ngx_kmp_out_track_publish_json(ngx_kmp_out_track_t *track,
     }
 
     upstreams = json.upstreams;
-    if (upstreams->type != NGX_JSON_OBJECT) {
+    if (upstreams->count != 0 && upstreams->type != NGX_JSON_OBJECT) {
         ngx_log_error(NGX_LOG_ERR, &track->log, 0,
             "ngx_kmp_out_track_publish_json: "
             "invalid upstreams element type %d", upstreams->type);


### PR DESCRIPTION
when the publish response contains an empty upstreams array, the data written to the kmp output track is silently discarded