### PR TITLE
ngx-kmp-out-upstream: copy upstream bugfix

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_upstream.c
@@ -127,6 +127,7 @@ ngx_kmp_out_upstream_copy(ngx_kmp_out_upstream_t *dst,
     dst->acked_frame_id = src->acked_frame_id;
     dst->acked_upstream_frame_id = src->acked_upstream_frame_id;
     dst->acked_offset = src->acked_offset;
+    dst->acked_bytes = src->acked_bytes;
 
     return NGX_OK;
 }


### PR DESCRIPTION
must copy 'acked_bytes' as well, otherwise when auto-acking packets, the module may try to read beyond the last packet that was written.