### PR TITLE
ngx-live: log the flags in 'invalid duration'

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -1304,7 +1304,7 @@ ngx_kmp_out_track_write_frame(ngx_kmp_out_track_t *track,
     } else {
         ngx_log_debug6(NGX_LOG_DEBUG_KMP, &track->log, 0,
             "ngx_kmp_out_track_write_frame: input: %V, created: %L, "
-            "size: %uD, dts: %L, flags: %uD, ptsDelay: %uD",
+            "size: %uD, dts: %L, flags: 0x%uxD, ptsDelay: %uD",
             &track->input_id.s, frame->f.created, frame->header.data_size,
             frame->f.dts, frame->f.flags, frame->f.pts_delay);
     }
@@ -1425,7 +1425,7 @@ ngx_kmp_out_track_write_frame_end(ngx_kmp_out_track_t *track,
     } else {
         ngx_log_debug6(NGX_LOG_DEBUG_KMP, &track->log, 0,
             "ngx_kmp_out_track_write_frame_end: input: %V, created: %L, "
-            "size: %uD, dts: %L, flags: %uD, ptsDelay: %uD",
+            "size: %uD, dts: %L, flags: 0x%uxD, ptsDelay: %uD",
             &track->input_id.s, frame->f.created, frame->header.data_size,
             frame->f.dts, frame->f.flags, frame->f.pts_delay);
     }

--- a/nginx-live-module/src/ngx_live_segmenter.c
+++ b/nginx-live-module/src/ngx_live_segmenter.c
@@ -972,8 +972,9 @@ ngx_live_segmenter_frame_list_copy(ngx_live_segmenter_frame_list_t *list,
             if (duration < 0 || duration > NGX_MAX_UINT32_VALUE) {
                 ngx_log_error(NGX_LOG_WARN, &track->log, 0,
                     "ngx_live_segmenter_frame_list_copy: "
-                    "invalid frame duration %L (1), dts: %L, prev: %L",
-                    duration, src->dts, prev_src->dts);
+                    "invalid frame duration %L (1), "
+                    "dts: %L, flags: 0x%uxD, prev_dts: %L",
+                    duration, src->dts, src->flags, prev_src->dts);
             }
 
             prev_dest->duration = duration;


### PR DESCRIPTION
also updated kmp-out to output frame flags in hex