### PR TITLE
ngx-live: avoid sending inactive events for subs

### DIFF
--- a/nginx-live-module/src/ngx_live_segmenter.c
+++ b/nginx-live-module/src/ngx_live_segmenter.c
@@ -1888,7 +1888,7 @@ ngx_live_segmenter_remove_frames(ngx_live_track_t *track, ngx_uint_t count,
     cctx = ngx_live_get_module_ctx(channel, ngx_live_segmenter_module);
 
     ctx->frame_count -= count;
-    if (ctx->frame_count <= 0) {
+    if (ctx->frame_count <= 0 && track->media_type != KMP_MEDIA_SUBTITLE) {
         (void) ngx_live_core_track_event(track,
             NGX_LIVE_EVENT_TRACK_INACTIVE, NULL);
     }

--- a/nginx-live-module/src/ngx_live_segmenter_ll.c
+++ b/nginx-live-module/src/ngx_live_segmenter_ll.c
@@ -1624,8 +1624,10 @@ ngx_live_lls_track_idle(ngx_live_track_t *track)
 
     ctx->fstate = ngx_live_lls_fs_idle;
 
-    (void) ngx_live_core_track_event(track,
-        NGX_LIVE_EVENT_TRACK_INACTIVE, NULL);
+    if (track->media_type != KMP_MEDIA_SUBTITLE) {
+        (void) ngx_live_core_track_event(track,
+            NGX_LIVE_EVENT_TRACK_INACTIVE, NULL);
+    }
 
     cctx->non_idle_tracks--;
     if (cctx->non_idle_tracks <= 0 && cctx->pending.nelts <= 0) {


### PR DESCRIPTION
unlike video/audio, subtitles are not expected to be continuous - it is possible that subtitles cues will be distributed sparsely. when an inactive event is sent, the syncer module resets itself, and outputs several log lines.
the main reason for avoiding the inactive event for subtitles is to remove this clutter from the log.