### PR TITLE
LIV-1191: fix RTMP timestamp restart

### DIFF
--- a/transcoder/config.json
+++ b/transcoder/config.json
@@ -1,11 +1,10 @@
 {
     "input": {
-        "file": "/media/worng_order_audio_only.ts",
-        "realTime": false,
+        "file": "",
+        "realTime": true,
         "activeStream": 0,
-        "xduration": 9000000,
-        "randomDataPercentage": 0,
-        "jumpOffsetSec": -60
+        "duration": 9000000,
+        "randomDataPercentage": 0
     },
     "frameDropper1": {
         "enabled": false,
@@ -57,7 +56,7 @@
     "outputTracks": [
         {
             "trackId": "v32",
-            "enabled": false,
+            "enabled": true,
             "passthrough": true
         },
         {
@@ -67,19 +66,19 @@
         },
         {
             "trackId": "a33",
-            "enabled": true,
-            "bitrate": 64000,
+            "enabled": false,
+            "bitrate": 64,
             "passthrough": false,
             "codec": "aac",
             "audioParams": {
-                "samplingRate": 44100,
+                "samplingRate": -1,
                 "channels": 2
             }
         },
         {
             "trackId": "v33",
             "passthrough": false,
-            "enabled": false,
+            "enabled": true,
             "bitrate": 900,
             "codec": "h264",
             "videoParams": {
@@ -90,7 +89,7 @@
         },
         {
             "trackId": "v34",
-            "enabled": false,
+            "enabled": true,
             "passthrough": false,
             "bitrate": 600,
             "codec": "h264",

--- a/transcoder/config_v.json
+++ b/transcoder/config_v.json
@@ -1,7 +1,7 @@
 {
     "input": {
-        "file": "/media/worng_order_audio_only.ts",
-        "realTime": false,
+        "file": "/media/worng_order_video_only.mp4",
+        "realTime": true,
         "activeStream": 0,
         "xduration": 9000000,
         "randomDataPercentage": 0,
@@ -67,20 +67,20 @@
         },
         {
             "trackId": "a33",
-            "enabled": true,
+            "enabled": false,
             "bitrate": 64000,
             "passthrough": false,
             "codec": "aac",
             "audioParams": {
-                "samplingRate": 44100,
+                "samplingRate": -1,
                 "channels": 2
             }
         },
         {
             "trackId": "v33",
             "passthrough": false,
-            "enabled": false,
-            "bitrate": 900,
+            "enabled": true,
+            "bitrate": 900000,
             "codec": "h264",
             "videoParams": {
                 "profile": "main",

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -119,10 +119,10 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
             pthread_mutex_lock(&server->diagnostics_locker);  // lock the critical section
             samples_stats_add(&server->receiverStats,packet->dts,packet->pos,packet->size);
             pthread_mutex_unlock(&server->diagnostics_locker);  // lock the critical section
-            LOGGER(CATEGORY_RECEIVER,AV_LOG_DEBUG,"[%s] received packet %s (%p) #: %lld",session->stream_name,getPacketDesc(packet),transcode_session,received_frame_id);
-            if(add_packet_frame_id(packet,received_frame_id)){
+            if(add_packet_frame_id(packet,received_frame_id,packet->pts)){
                 LOGGER(CATEGORY_RECEIVER,AV_LOG_ERROR,"[%s] failed to set frame id %lld on packet",session->stream_name,received_frame_id);
             }
+            LOGGER(CATEGORY_RECEIVER,AV_LOG_DEBUG,"[%s] received packet %s (%p) #: %lld",session->stream_name,getPacketDesc(packet),transcode_session,received_frame_id);
             _S(transcode_session_async_send_packet(transcode_session, packet));
             av_packet_free(&packet);
             received_frame_id++;

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -119,7 +119,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
             pthread_mutex_lock(&server->diagnostics_locker);  // lock the critical section
             samples_stats_add(&server->receiverStats,packet->dts,packet->pos,packet->size);
             pthread_mutex_unlock(&server->diagnostics_locker);  // lock the critical section
-            if(add_packet_frame_id(packet,received_frame_id,packet->pts)){
+            if(add_packet_frame_id_and_pts(packet,received_frame_id,packet->pts)){
                 LOGGER(CATEGORY_RECEIVER,AV_LOG_ERROR,"[%s] failed to set frame id %lld on packet",session->stream_name,received_frame_id);
             }
             LOGGER(CATEGORY_RECEIVER,AV_LOG_DEBUG,"[%s] received packet %s (%p) #: %lld",session->stream_name,getPacketDesc(packet),transcode_session,received_frame_id);

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -388,7 +388,7 @@ encoder_error:
                getPacketDesc(pOutPacket),
                encoderId);
         output_frame_id = pContext->transcoded_frame_first_id+pOutput->stats.totalFrames;
-        add_packet_frame_id(pOutPacket,output_frame_id,pOutPacket->pts);
+        add_packet_frame_id_and_pts(pOutPacket,output_frame_id,pOutPacket->pts);
 
         pOutPacket->pos=clock_estimator_get_clock(&pContext->clock_estimator,pOutPacket->dts);
 
@@ -593,7 +593,7 @@ int OnDecodedFrame(transcode_session_t *ctx,AVCodecContext* decoderCtx, AVFrame 
 
     // we do not rely on decoder timestamps since it does not
     // take into account arbitrary jumps.
-    if(!get_frame_pts(frame,&pts)) {
+    if(!get_frame_original_pts(frame,&pts)) {
         frame->pts = frame->pkt_dts = pts;
     }
 

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -197,7 +197,7 @@ void get_filter_config(transcode_session_t *pSession,char *filterConfig,  transc
         char buf[64];
         av_get_channel_layout_string(buf,sizeof(buf),
             codec->ctx->channels,codec->ctx->channel_layout);
-        sprintf(filterConfig,"aresample=async=1000:out_sample_rate=%d:out_channel_layout=%s",
+        sprintf(filterConfig,"aresample=async=0:out_sample_rate=%d:out_channel_layout=%s",
             codec->ctx->sample_rate,buf);
     }
 }
@@ -383,13 +383,12 @@ encoder_error:
             goto encoder_error;
         }
 
-        output_frame_id = pContext->transcoded_frame_first_id+pOutput->stats.totalFrames;
-        add_packet_frame_id(pOutPacket,output_frame_id);
-
         LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] received encoded frame %s from encoder Id %d",
                pOutput->track_id,
                getPacketDesc(pOutPacket),
                encoderId);
+        output_frame_id = pContext->transcoded_frame_first_id+pOutput->stats.totalFrames;
+        add_packet_frame_id(pOutPacket,output_frame_id,pOutPacket->pts);
 
         pOutPacket->pos=clock_estimator_get_clock(&pContext->clock_estimator,pOutPacket->dts);
 
@@ -572,6 +571,7 @@ static void shift_audio_samples(AVFrame *frame,int shift_by) {
 
 int OnDecodedFrame(transcode_session_t *ctx,AVCodecContext* decoderCtx, AVFrame *frame)
 {
+   uint64_t pts;
    for (int outputId=0;outputId<ctx->outputs;outputId++) {
          transcode_session_output_t *pOutput=&ctx->output[outputId];
          if (!pOutput->passthrough && pOutput->encoderId==-1) {
@@ -591,7 +591,11 @@ int OnDecodedFrame(transcode_session_t *ctx,AVCodecContext* decoderCtx, AVFrame 
         return 0;
     }
 
-
+    // we do not rely on decoder timestamps since it does not
+    // take into account arbitrary jumps.
+    if(!get_frame_pts(frame,&pts)) {
+        frame->pts = frame->pkt_dts = pts;
+    }
 
     if(ctx->offset > 0){
         if(decoderCtx->codec_type == AVMEDIA_TYPE_AUDIO) {

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -593,12 +593,9 @@ int OnDecodedFrame(transcode_session_t *ctx,AVCodecContext* decoderCtx, AVFrame 
 
     // we do not rely on decoder timestamps since it does not
     // take into account arbitrary jumps.
-    LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] before pts",ctx->name);
     if(!get_frame_original_pts(frame,&pts)) {
-        LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] pts is %d",ctx->name, pts);
         frame->pts = frame->pkt_dts = pts;
     }
-    LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] after pts",ctx->name);
 
     if(ctx->offset > 0){
         if(decoderCtx->codec_type == AVMEDIA_TYPE_AUDIO) {

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -593,9 +593,12 @@ int OnDecodedFrame(transcode_session_t *ctx,AVCodecContext* decoderCtx, AVFrame 
 
     // we do not rely on decoder timestamps since it does not
     // take into account arbitrary jumps.
+    LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] before pts",ctx->name);
     if(!get_frame_original_pts(frame,&pts)) {
+        LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] pts is %d",ctx->name, pts);
         frame->pts = frame->pkt_dts = pts;
     }
+    LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] after pts",ctx->name);
 
     if(ctx->offset > 0){
         if(decoderCtx->codec_type == AVMEDIA_TYPE_AUDIO) {

--- a/transcoder/utils/utils.c
+++ b/transcoder/utils/utils.c
@@ -145,7 +145,7 @@ char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
     get_frame_id(pFrame,&frame_id);
     get_packet_original_pts(pFrame,&pts);
     if (pFrame->width>0) {
-        snprintf(buf,size,"pts=%s;samples=%d;clock=%s;key=%s;data=%p;hwctx=%p;format=%s;pictype=%s;width=%d;height=%d;ar=%d/%d;has_53cc=%d;frame_id=%ld;pts=%s",
+        snprintf(buf,size,"pts=%s;samples=%d;clock=%s;key=%s;data=%p;hwctx=%p;format=%s;pictype=%s;width=%d;height=%d;ar=%d/%d;has_53cc=%d;frame_id=%ld;orig_pts=%s",
              pts2str(pFrame->pts),
              pFrame->nb_samples,
              pFrame->pkt_pos != 0 ? ts2str(pFrame->pkt_pos,false) :  "N/A",
@@ -158,7 +158,9 @@ char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
              pFrame->height,
              pFrame->sample_aspect_ratio.num,
              pFrame->sample_aspect_ratio.den,
-             av_frame_get_side_data(pFrame,AV_FRAME_DATA_A53_CC) != NULL, frame_id, pts2str(pts));
+             av_frame_get_side_data(pFrame,AV_FRAME_DATA_A53_CC) != NULL,
+             frame_id,
+             pts2str(pts));
     } else {
         snprintf(buf,size,"pts=%s;channels=%d;sampleRate=%d;format=%d;size=%d;channel_layout=%ld;frame_id=%ld;orig_pts=%s",
                  pts2str(pFrame->pts),
@@ -213,14 +215,14 @@ char *av_pts_to_string(char *buf, int64_t pts)
     if(AV_NOPTS_VALUE == pts){
         strcpy(buf,"AV_NOPTS_VALUE");
     } else {
-        int64_t totalSeconds=llabs(pts/90000);
-        int milliseconds=abs((int)(pts % 90000)/90);
+        int64_t totalSeconds = llabs(pts/90000);
+        int milliseconds = abs((int)(pts % 90000)/90);
         int seconds = (totalSeconds % 60);
         int minutes = (totalSeconds % 3600) / 60;
         int hours = (totalSeconds % 86400) / 3600;
         int days = (int)(totalSeconds / 86400);
 
-        if (days==0) {
+        if (days == 0) {
             sprintf(buf,"%s%.2d:%.2d:%.2d.%.3d",pts>=0 ? "" : "-",hours,minutes,seconds,milliseconds);
         } else {
             sprintf(buf,"%s%d.%.2d:%.2d:%.2d.%.3d",pts>=0 ? "" : "-",days,hours,minutes,seconds,milliseconds);

--- a/transcoder/utils/utils.c
+++ b/transcoder/utils/utils.c
@@ -258,7 +258,7 @@ void log_frame_side_data(const char* category,const AVFrame *pFrame)
     }
 }
 
-int add_packet_frame_id(AVPacket *packet,int64_t frame_id,int64_t pts) {
+int add_packet_frame_id(AVPacket *packet,int64_t frame_id,pts_t pts) {
      AVDictionary * frameDict = NULL;
      int frameDictSize = 0;
      char buf[sizeof("9223372036854775807")];
@@ -295,7 +295,7 @@ int get_packet_frame_id(const AVPacket *packet,int64_t *frame_id_ptr)
     return 0;
 }
 
-int get_packet_pts(const AVPacket *packet,int64_t *pts_ptr)
+int get_packet_pts(const AVPacket *packet,pts_t *pts_ptr)
 {
     const char *pts_str;
      AVDictionary * frameDict = NULL;
@@ -308,7 +308,7 @@ int get_packet_pts(const AVPacket *packet,int64_t *pts_ptr)
     pts_str = av_dict_get(frameDict, "pts", NULL, 0)->value;
     if(!pts_str)
        return AVERROR(EINVAL);
-    *pts_ptr = strtoull(pts_str,NULL,10);
+    *pts_ptr = strtoll(pts_str,NULL,10);
     av_dict_free(&frameDict);
     return 0;
 }
@@ -327,14 +327,14 @@ int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr)
     return AVERROR(EINVAL);
 }
 
-int get_frame_pts(const AVFrame *frame,int64_t *pts_ptr)
+int get_frame_pts(const AVFrame *frame,pts_t *pts_ptr)
 {
     *pts_ptr = AV_NOPTS_VALUE;
     if(frame->metadata) {
         const char *pts_str = av_dict_get(frame->metadata, "pts", NULL, 0)->value;
          if(!pts_str)
             return AVERROR(EINVAL);
-        *pts_ptr = strtoull(pts_str,NULL,10);
+        *pts_ptr = strtoll(pts_str,NULL,10);
         return 0;
     }
     return AVERROR(EINVAL);

--- a/transcoder/utils/utils.c
+++ b/transcoder/utils/utils.c
@@ -143,7 +143,7 @@ char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
         return "<NULL>";
     }
     get_frame_id(pFrame,&frame_id);
-    get_frame_pts(pFrame,&pts);
+    get_packet_original_pts(pFrame,&pts);
     if (pFrame->width>0) {
         snprintf(buf,size,"pts=%s;samples=%d;clock=%s;key=%s;data=%p;hwctx=%p;format=%s;pictype=%s;width=%d;height=%d;ar=%d/%d;has_53cc=%d;frame_id=%ld;pts=%s",
              pts2str(pFrame->pts),
@@ -160,7 +160,7 @@ char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
              pFrame->sample_aspect_ratio.den,
              av_frame_get_side_data(pFrame,AV_FRAME_DATA_A53_CC) != NULL, frame_id, pts2str(pts));
     } else {
-        snprintf(buf,size,"pts=%s;channels=%d;sampleRate=%d;format=%d;size=%d;channel_layout=%ld;frame_id=%ld;pts=%s",
+        snprintf(buf,size,"pts=%s;channels=%d;sampleRate=%d;format=%d;size=%d;channel_layout=%ld;frame_id=%ld;orig_pts=%s",
                  pts2str(pFrame->pts),
                  pFrame->channels,pFrame->sample_rate,pFrame->format,pFrame->nb_samples,pFrame->channel_layout,frame_id,pts2str(pts));
     }
@@ -175,9 +175,9 @@ char *av_get_packet_desc(char *buf,int len,const  AVPacket * packet)
         return "<NULL>";
     }
     get_packet_frame_id(packet,&frame_id);
-    get_packet_pts(packet,&pts);
+    get_packet_original_pts(packet,&pts);
 
-    snprintf(buf,len,"mem=%p;data=%p;pts=%s;dts=%s;dur=%s;clock=%s;key=%s;size=%d;flags=%d;frame_id=%ld;pts=%s",
+    snprintf(buf,len,"mem=%p;data=%p;pts=%s;dts=%s;dur=%s;clock=%s;key=%s;size=%d;flags=%d;frame_id=%ld;orig_pts=%s",
              packet,
              packet->data,
              pts2str(packet->pts),
@@ -210,17 +210,21 @@ char* av_socket_info(char* buf,int len,const struct sockaddr_in* sa)
 
 char *av_pts_to_string(char *buf, int64_t pts)
 {
-    int64_t totalSeconds=llabs(pts/90000);
-    int milliseconds=abs((int)(pts % 90000)/90);
-    int seconds = (totalSeconds % 60);
-    int minutes = (totalSeconds % 3600) / 60;
-    int hours = (totalSeconds % 86400) / 3600;
-    int days = (int)(totalSeconds / 86400);
-
-    if (days==0) {
-        sprintf(buf,"%s%.2d:%.2d:%.2d.%.3d",pts>=0 ? "" : "-",hours,minutes,seconds,milliseconds);
+    if(AV_NOPTS_VALUE == pts){
+        strcpy(buf,"AV_NOPTS_VALUE");
     } else {
-        sprintf(buf,"%s%d %.2d:%.2d:%.2d.%.3d",pts>=0 ? "" : "-",days,hours,minutes,seconds,milliseconds);
+        int64_t totalSeconds=llabs(pts/90000);
+        int milliseconds=abs((int)(pts % 90000)/90);
+        int seconds = (totalSeconds % 60);
+        int minutes = (totalSeconds % 3600) / 60;
+        int hours = (totalSeconds % 86400) / 3600;
+        int days = (int)(totalSeconds / 86400);
+
+        if (days==0) {
+            sprintf(buf,"%s%.2d:%.2d:%.2d.%.3d",pts>=0 ? "" : "-",hours,minutes,seconds,milliseconds);
+        } else {
+            sprintf(buf,"%s%d.%.2d:%.2d:%.2d.%.3d",pts>=0 ? "" : "-",days,hours,minutes,seconds,milliseconds);
+        }
     }
     return buf;
 }
@@ -258,7 +262,7 @@ void log_frame_side_data(const char* category,const AVFrame *pFrame)
     }
 }
 
-int add_packet_frame_id(AVPacket *packet,int64_t frame_id,pts_t pts) {
+int add_packet_frame_id_and_pts(AVPacket *packet,int64_t frame_id,pts_t pts) {
      AVDictionary * frameDict = NULL;
      int frameDictSize = 0;
      char buf[sizeof("9223372036854775807")];
@@ -295,7 +299,7 @@ int get_packet_frame_id(const AVPacket *packet,int64_t *frame_id_ptr)
     return 0;
 }
 
-int get_packet_pts(const AVPacket *packet,pts_t *pts_ptr)
+int get_packet_original_pts(const AVPacket *packet,pts_t *pts_ptr)
 {
     const char *pts_str;
      AVDictionary * frameDict = NULL;
@@ -327,7 +331,7 @@ int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr)
     return AVERROR(EINVAL);
 }
 
-int get_frame_pts(const AVFrame *frame,pts_t *pts_ptr)
+int get_frame_original_pts(const AVFrame *frame,pts_t *pts_ptr)
 {
     *pts_ptr = AV_NOPTS_VALUE;
     if(frame->metadata) {

--- a/transcoder/utils/utils.c
+++ b/transcoder/utils/utils.c
@@ -138,12 +138,14 @@ const char* pict_type_to_string(int pt) {
 char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
 {
     uint64_t frame_id;
+    int64_t pts = AV_NOPTS_VALUE;
     if (pFrame==NULL) {
         return "<NULL>";
     }
     get_frame_id(pFrame,&frame_id);
+    get_frame_pts(pFrame,&pts);
     if (pFrame->width>0) {
-        snprintf(buf,size,"pts=%s;samples=%d;clock=%s;key=%s;data=%p;hwctx=%p;format=%s;pictype=%s;width=%d;height=%d;ar=%d/%d;has_53cc=%d;frame_id=%ld",
+        snprintf(buf,size,"pts=%s;samples=%d;clock=%s;key=%s;data=%p;hwctx=%p;format=%s;pictype=%s;width=%d;height=%d;ar=%d/%d;has_53cc=%d;frame_id=%ld;pts=%s",
              pts2str(pFrame->pts),
              pFrame->nb_samples,
              pFrame->pkt_pos != 0 ? ts2str(pFrame->pkt_pos,false) :  "N/A",
@@ -156,11 +158,11 @@ char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
              pFrame->height,
              pFrame->sample_aspect_ratio.num,
              pFrame->sample_aspect_ratio.den,
-             av_frame_get_side_data(pFrame,AV_FRAME_DATA_A53_CC) != NULL, frame_id);
+             av_frame_get_side_data(pFrame,AV_FRAME_DATA_A53_CC) != NULL, frame_id, pts2str(pts));
     } else {
-        snprintf(buf,size,"pts=%s;channels=%d;sampleRate=%d;format=%d;size=%d;channel_layout=%ld;frame_id=%ld",
+        snprintf(buf,size,"pts=%s;channels=%d;sampleRate=%d;format=%d;size=%d;channel_layout=%ld;frame_id=%ld;pts=%s",
                  pts2str(pFrame->pts),
-                 pFrame->channels,pFrame->sample_rate,pFrame->format,pFrame->nb_samples,pFrame->channel_layout,frame_id);
+                 pFrame->channels,pFrame->sample_rate,pFrame->format,pFrame->nb_samples,pFrame->channel_layout,frame_id,pts2str(pts));
     }
     return buf;
 }
@@ -168,11 +170,14 @@ char *av_get_frame_desc(char* buf, int size,const AVFrame * pFrame)
 char *av_get_packet_desc(char *buf,int len,const  AVPacket * packet)
 {
     int64_t frame_id;
+    int64_t pts = AV_NOPTS_VALUE;
     if (packet==NULL) {
         return "<NULL>";
     }
     get_packet_frame_id(packet,&frame_id);
-    snprintf(buf,len,"mem=%p;data=%p;pts=%s;dts=%s;dur=%s;clock=%s;key=%s;size=%d;flags=%d;frame_id=%ld",
+    get_packet_pts(packet,&pts);
+
+    snprintf(buf,len,"mem=%p;data=%p;pts=%s;dts=%s;dur=%s;clock=%s;key=%s;size=%d;flags=%d;frame_id=%ld;pts=%s",
              packet,
              packet->data,
              pts2str(packet->pts),
@@ -182,7 +187,8 @@ char *av_get_packet_desc(char *buf,int len,const  AVPacket * packet)
              (packet->flags & AV_PKT_FLAG_KEY)==AV_PKT_FLAG_KEY ? "Yes" : "No",
              packet->size,
              packet->flags,
-             frame_id);
+             frame_id,
+             pts2str(pts));
     return buf;
 }
 
@@ -252,13 +258,15 @@ void log_frame_side_data(const char* category,const AVFrame *pFrame)
     }
 }
 
-int add_packet_frame_id(AVPacket *packet,int64_t frame_id) {
+int add_packet_frame_id(AVPacket *packet,int64_t frame_id,int64_t pts) {
      AVDictionary * frameDict = NULL;
      int frameDictSize = 0;
      char buf[sizeof("9223372036854775807")];
      uint8_t *frameDictData = NULL;
      sprintf(buf,"%lld",frame_id);
      _S(av_dict_set(&frameDict, "frame_id", buf, 0));
+     sprintf(buf,"%lld",pts);
+     _S(av_dict_set(&frameDict, "pts", buf, 0));
      // Pack dictionary to be able to use it as a side data in AVPacket
      frameDictData = av_packet_pack_dictionary(frameDict, &frameDictSize);
      if(!frameDictData)
@@ -287,6 +295,25 @@ int get_packet_frame_id(const AVPacket *packet,int64_t *frame_id_ptr)
     return 0;
 }
 
+int get_packet_pts(const AVPacket *packet,int64_t *pts_ptr)
+{
+    const char *pts_str;
+     AVDictionary * frameDict = NULL;
+     int frameDictSize = 0;
+     uint8_t *frameDictData = av_packet_get_side_data(packet, AV_PKT_DATA_STRINGS_METADATA, &frameDictSize);
+     *pts_ptr = AV_NOPTS_VALUE;
+     if (!frameDictData)
+        return AVERROR(EINVAL);
+    _S(av_packet_unpack_dictionary(frameDictData,frameDictSize,&frameDict));
+    pts_str = av_dict_get(frameDict, "pts", NULL, 0)->value;
+    if(!pts_str)
+       return AVERROR(EINVAL);
+    *pts_ptr = strtoull(pts_str,NULL,10);
+    av_dict_free(&frameDict);
+    return 0;
+}
+
+
 int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr)
 {
     *frame_id_ptr = AV_NOPTS_VALUE;
@@ -295,6 +322,19 @@ int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr)
          if(!frame_str)
             return AVERROR(EINVAL);
         *frame_id_ptr = strtoull(frame_str,NULL,10);
+        return 0;
+    }
+    return AVERROR(EINVAL);
+}
+
+int get_frame_pts(const AVFrame *frame,int64_t *pts_ptr)
+{
+    *pts_ptr = AV_NOPTS_VALUE;
+    if(frame->metadata) {
+        const char *pts_str = av_dict_get(frame->metadata, "pts", NULL, 0)->value;
+         if(!pts_str)
+            return AVERROR(EINVAL);
+        *pts_ptr = strtoull(pts_str,NULL,10);
         return 0;
     }
     return AVERROR(EINVAL);

--- a/transcoder/utils/utils.h
+++ b/transcoder/utils/utils.h
@@ -32,12 +32,13 @@ char *av_get_frame_desc(char *buf,int len, const AVFrame * frame);
 char *av_get_packet_desc(char *buf,int len, const AVPacket * packet);
 char* av_socket_info(char* buf,int len,const struct sockaddr_in* sa);
 void log_frame_side_data(const char* category,const AVFrame *pFrame);
-int add_packet_frame_id(AVPacket *packet,int64_t frame_id,int64_t pts);
+typedef int64_t pts_t;
+int add_packet_frame_id(AVPacket *packet,int64_t frame_id,pts_t pts);
 int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr);
 int get_packet_frame_id(const AVPacket *packet,int64_t *frame_id_ptr);
-int add_packet_pts(AVPacket *packet,uint64_t pts);
-int get_packet_pts(const AVPacket *packet,int64_t *pts_ptr);
-int get_frame_pts(const AVFrame *frame,int64_t *pts_ptr);
+int add_packet_pts(AVPacket *packet,pts_t pts);
+int get_packet_pts(const AVPacket *packet,pts_t *pts_ptr);
+int get_frame_pts(const AVFrame *frame,pts_t *pts_ptr);
 /**
  * Convenience macro, the return value should be used only directly in
  * function arguments but never stand-alone.

--- a/transcoder/utils/utils.h
+++ b/transcoder/utils/utils.h
@@ -32,9 +32,12 @@ char *av_get_frame_desc(char *buf,int len, const AVFrame * frame);
 char *av_get_packet_desc(char *buf,int len, const AVPacket * packet);
 char* av_socket_info(char* buf,int len,const struct sockaddr_in* sa);
 void log_frame_side_data(const char* category,const AVFrame *pFrame);
-int add_packet_frame_id(AVPacket *packet,int64_t frame_id);
+int add_packet_frame_id(AVPacket *packet,int64_t frame_id,int64_t pts);
 int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr);
 int get_packet_frame_id(const AVPacket *packet,int64_t *frame_id_ptr);
+int add_packet_pts(AVPacket *packet,uint64_t pts);
+int get_packet_pts(const AVPacket *packet,int64_t *pts_ptr);
+int get_frame_pts(const AVFrame *frame,int64_t *pts_ptr);
 /**
  * Convenience macro, the return value should be used only directly in
  * function arguments but never stand-alone.

--- a/transcoder/utils/utils.h
+++ b/transcoder/utils/utils.h
@@ -33,12 +33,11 @@ char *av_get_packet_desc(char *buf,int len, const AVPacket * packet);
 char* av_socket_info(char* buf,int len,const struct sockaddr_in* sa);
 void log_frame_side_data(const char* category,const AVFrame *pFrame);
 typedef int64_t pts_t;
-int add_packet_frame_id(AVPacket *packet,int64_t frame_id,pts_t pts);
+int add_packet_frame_id_and_pts(AVPacket *packet,int64_t frame_id,pts_t pts);
 int get_frame_id(const AVFrame *frame,uint64_t *frame_id_ptr);
 int get_packet_frame_id(const AVPacket *packet,int64_t *frame_id_ptr);
-int add_packet_pts(AVPacket *packet,pts_t pts);
-int get_packet_pts(const AVPacket *packet,pts_t *pts_ptr);
-int get_frame_pts(const AVFrame *frame,pts_t *pts_ptr);
+int get_packet_original_pts(const AVPacket *packet,pts_t *pts_ptr);
+int get_frame_original_pts(const AVFrame *frame,pts_t *pts_ptr);
 /**
  * Convenience macro, the return value should be used only directly in
  * function arguments but never stand-alone.


### PR DESCRIPTION
ffmpeg decoder produce wrong timestamps when there is a jump backwards.
except for being out of sync with ingest , in the case of audio resampler async set to non zero value it will chop off all incoming streram by said amount thus causing missing audio pieces for the duration of the jump. 