### PR TITLE
Update base Docker images for compatibility

### DIFF
--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.8
 
 FROM $IMAGE_NAMESPACE/transcoder-dev:$BUILD_TAG as dev
 
-FROM python:${PYTHON_VERSION}-slim-buster
+FROM python:${PYTHON_VERSION}-slim-bullseye
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES video,compute,utility

--- a/transcoder/Dockerfile.build
+++ b/transcoder/Dockerfile.build
@@ -1,7 +1,7 @@
 #docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it -v ~/dev/live/transcoder:/tmp   -p 6543:6543 kaltura/live-transcoder  
 #gdb --args ./transcoder -f /tmp/config2.json
 
-ARG  CUDA_VERSION="11.1.1-devel"
+ARG  CUDA_VERSION="11.1.1-devel-ubuntu20.04"
 
 ARG PYTHON_VERSION=3.8
 


### PR DESCRIPTION
- Update base images to align with the README instructions in the 'example conf' folder.
- Resolve runtime error due to missing `GLIBCXX_3.4.26` in libstdc++.so.6 required by /build/transcoder.