### PR TITLE
LIV-1205: Transcoder overload protection.

### DIFF
--- a/transcoder/common/json_parser.c
+++ b/transcoder/common/json_parser.c
@@ -1000,6 +1000,6 @@ json_status_t json_get_double(const json_value_t* obj,char* path,double defaultV
     if (jresult->type!=JSON_FRAC) {
         return JSON_BAD_DATA;
     }
-    *result = ((double)jresult->v.num.denom) / ((double)jresult->v.num.num);
+    *result = ((double)jresult->v.num.num) / ((double)jresult->v.num.denom);
     return JSON_OK;
 }

--- a/transcoder/config_v.json
+++ b/transcoder/config_v.json
@@ -5,7 +5,9 @@
         "activeStream": 0,
         "xduration": 9000000,
         "randomDataPercentage": 0,
-        "jumpOffsetSec": -60
+        "jumpOffsetSec": -60,
+        "hiccupIntervalSec": 0,
+        "hiccupDurationSec": 0
     },
     "throttler": {
         "maxDataRate": 1.5,

--- a/transcoder/config_v.json
+++ b/transcoder/config_v.json
@@ -8,7 +8,7 @@
         "jumpOffsetSec": -60
     },
     "throttler": {
-        "maxDataRate": 2.5,
+        "maxDataRate": 1.5,
         "coldSeconds": 0,
         "minThrottleWaitMs": 1
     },

--- a/transcoder/config_v.json
+++ b/transcoder/config_v.json
@@ -1,11 +1,16 @@
 {
     "input": {
         "file": "/media/worng_order_video_only.mp4",
-        "realTime": true,
+        "realTime": false,
         "activeStream": 0,
         "xduration": 9000000,
         "randomDataPercentage": 0,
         "jumpOffsetSec": -60
+    },
+    "throttler": {
+        "maxDataRate": 2.5,
+        "coldSeconds": 0,
+        "minThrottleWaitMs": 1
     },
     "frameDropper1": {
         "enabled": false,

--- a/transcoder/debug/file_streamer.c
+++ b/transcoder/debug/file_streamer.c
@@ -49,8 +49,13 @@ void* thread_stream_from_file(void *vargp)
     char channelId[KMP_MAX_CHANNEL_ID];
     json_get_string(GetConfig(),"input.channelId","1_abcdefgh",channelId,sizeof(channelId));
 
-    int jumpOffsetSec=0;
+    int64_t jumpOffsetSec=0;
     json_get_int64(GetConfig(),"input.jumpoffsetsec",0,&jumpOffsetSec);
+
+    int64_t hiccupDurationSec, hiccupIntervalSec;
+    json_get_int64(GetConfig(),"input.hiccupDurationSec",0,&hiccupDurationSec);
+
+    json_get_int64(GetConfig(),"input.hiccupIntervalSec",0,&hiccupIntervalSec);
 
     AVPacket packet;
     av_init_packet(&packet);
@@ -86,8 +91,10 @@ void* thread_stream_from_file(void *vargp)
     LOGGER("SENDER",AV_LOG_INFO,"Realtime = %s",realTime ? "true" : "false");
     srand((int)time(NULL));
     uint64_t lastDts=0;
-    int64_t start_time=av_gettime_relative();
-
+    int64_t start_time=av_gettime_relative(),
+            hiccup_duration =  hiccupDurationSec * 1000 * 1000,
+            hiccup_interval = hiccupIntervalSec * 1000 * 1000,
+            next_hiccup = start_time + hiccup_interval;
 
     samples_stats_t stats;
     sample_stats_init(&stats,standard_timebase);
@@ -144,6 +151,18 @@ void* thread_stream_from_file(void *vargp)
 
             int64_t timePassed=av_rescale_q(packet.dts,standard_timebase,AV_TIME_BASE_Q) + start_time,
                     clockPassed = av_gettime_relative();
+
+           if(clockPassed >= next_hiccup && clockPassed < next_hiccup + hiccup_duration) {
+               next_hiccup += hiccup_duration;
+               LOGGER("SENDER",AV_LOG_INFO,"hiccup! [ %ld - %ld ]",
+                ts2str((clockPassed - start_time) * 90,true),
+                ts2str((next_hiccup  - start_time) * 90,true));
+
+               av_usleep(next_hiccup - clockPassed);
+
+               next_hiccup = av_gettime_relative() + hiccup_interval;
+           }
+
             LOGGER("SENDER",AV_LOG_DEBUG,"XXXX clockPassed=%ld timePassed=%ld", clockPassed - start_time,timePassed - start_time);
             while (clockPassed < timePassed) {
 

--- a/transcoder/debug/file_streamer.c
+++ b/transcoder/debug/file_streamer.c
@@ -142,12 +142,14 @@ void* thread_stream_from_file(void *vargp)
 
         if (realTime && lastDts > 0) {
 
-            int64_t timePassed=av_rescale_q(packet.dts-lastDts,standard_timebase,AV_TIME_BASE_Q);
-            //LOGGER("SENDER",AV_LOG_DEBUG,"XXXX dt=%ld dd=%ld", (av_gettime_relative() - start_time),timePassed);
-            while ((av_gettime_relative() - start_time) < timePassed) {
+            int64_t timePassed=av_rescale_q(packet.dts,standard_timebase,AV_TIME_BASE_Q) + start_time,
+                    clockPassed = av_gettime_relative();
+            LOGGER("SENDER",AV_LOG_DEBUG,"XXXX clockPassed=%ld timePassed=%ld", clockPassed - start_time,timePassed - start_time);
+            while (clockPassed < timePassed) {
 
                 LOGGER0("SENDER",AV_LOG_DEBUG,"XXXX Sleep 10ms");
                 av_usleep(10*1000);//10ms
+                clockPassed = av_gettime_relative();
             }
         }
 
@@ -179,7 +181,7 @@ void* thread_stream_from_file(void *vargp)
          LOGGER("SENDER",AV_LOG_DEBUG,"sent packet pts=%s dts=%s  size=%d",
          ts2str(packet.pts,true),
          ts2str(packet.dts,true),
-         packet.dts,packet.size);
+         packet.size);
 
 
         av_packet_unref(&packet);

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -28,9 +28,8 @@ int atomFileWrite (char* fileName,char* content,size_t size)
 int processedFrameCB(receiver_server_session_t *session,bool completed)
 {
     uint64_t now=av_gettime();
-    receiver_server_t *server=session->server;
     if (completed || now-session->lastStatsUpdated>session->diagnosticsIntervalInSeconds) {//1 second interval
-
+        receiver_server_t *server=session->server;
 
 
         char* tmpBuf=av_malloc(MAX_DIAGNOSTICS_STRING_LENGTH);

--- a/transcoder/tests/config_a.json
+++ b/transcoder/tests/config_a.json
@@ -10,7 +10,7 @@
     },
     "throttler": {
         "maxDataRate": 1.5,
-        "coldSeconds": 0,
+        "useStatsDataRate": false,
         "minThrottleWaitMs": 1
     },
     "frameDropper1": {

--- a/transcoder/tests/config_a.json
+++ b/transcoder/tests/config_a.json
@@ -1,13 +1,12 @@
 {
     "input": {
-        "file": "/media/worng_order_video_only.mp4",
+        "file": "/media/worng_order_audio_only.ts",
         "realTime": false,
         "activeStream": 0,
-        "xduration": 9000000,
+        "zduration": 9000000,
         "randomDataPercentage": 0,
-        "jumpOffsetSec": -60,
-        "hiccupIntervalSec": 0,
-        "hiccupDurationSec": 0
+        "xhiccupIntervalSec": 5,
+        "xhiccupDurationSec": 2
     },
     "throttler": {
         "maxDataRate": 1.5,
@@ -69,13 +68,13 @@
         },
         {
             "trackId": "a32",
-            "enabled": false,
+            "enabled": true,
             "passthrough": true
         },
         {
             "trackId": "a33",
-            "enabled": false,
-            "bitrate": 64000,
+            "enabled": true,
+            "bitrate": 64,
             "passthrough": false,
             "codec": "aac",
             "audioParams": {
@@ -86,8 +85,8 @@
         {
             "trackId": "v33",
             "passthrough": false,
-            "enabled": true,
-            "bitrate": 900000,
+            "enabled": false,
+            "bitrate": 900,
             "codec": "h264",
             "videoParams": {
                 "profile": "main",

--- a/transcoder/tests/config_v.json
+++ b/transcoder/tests/config_v.json
@@ -1,0 +1,148 @@
+{
+    "input": {
+        "file": "/media/worng_order_video_only.mp4",
+        "realTime": false,
+        "activeStream": 0,
+        "xduration": 9000000,
+        "randomDataPercentage": 0,
+        "jumpOffsetSec": -60,
+        "hiccupIntervalSec": 0,
+        "hiccupDurationSec": 0
+    },
+    "throttler": {
+        "maxDataRate": 1.5,
+        "coldSeconds": 1,
+        "minThrottleWaitMs": 1
+    },
+    "frameDropper1": {
+        "enabled": false,
+        "queueDuration": 10,
+        "queueSize": 0,
+        "nonKeyFrameDropperThreshold": 4,
+        "decodedFrameDropperThreshold": 2
+    },
+    "logger": {
+        "logLevels": ["DEBUG","VERBOSE","INFO","WARN","ERROR","FATAL","PANIC"],
+        "logLevel": "DEBUG"
+    },
+    "kmp": {
+        "listenPort": 16543,
+        "listenAddress": "0.0.0.0",
+        "acceptTimeout": 15,
+        "idleTimeout": 10,
+        "connectTimeout": 10
+    },
+    "control": {
+        "listenPort": 18001,
+        "listenAddress": "0.0.0.0"
+    },
+    "debug": {
+        "diagnosticsIntervalInSeconds": 1
+    },
+    "output": {
+        "saveFile": true,
+        "outputFileNamePattern": "./output_%s.ts",
+        "streamingUrla": "kmp://localhost:6543",
+        "streamingUrl12": "kmp://192.168.11.59:6543",
+        "streamingUrl1": ""
+    },
+    "engine": {
+        "encoders": {
+            "h264": ["h264_nvenc","libx264","h264_videotoolbox"]
+        },
+        "presets": {
+            "A": {
+                "h264_videotoolbox": "default",
+                "libx264": "veryfast",
+                "h264_nvenc": "fast"
+            }
+        }
+    },
+    "errorPolicy": {
+        "exitOnError": false
+    },
+    "outputTracks": [
+        {
+            "trackId": "v32",
+            "enabled": false,
+            "passthrough": true
+        },
+        {
+            "trackId": "a32",
+            "enabled": false,
+            "passthrough": true
+        },
+        {
+            "trackId": "a33",
+            "enabled": false,
+            "bitrate": 64000,
+            "passthrough": false,
+            "codec": "aac",
+            "audioParams": {
+                "samplingRate": -1,
+                "channels": 2
+            }
+        },
+        {
+            "trackId": "v33",
+            "passthrough": false,
+            "enabled": true,
+            "bitrate": 900000,
+            "codec": "h264",
+            "videoParams": {
+                "profile": "main",
+                "preset": "A",
+                "height": 480
+            }
+        },
+        {
+            "trackId": "v34",
+            "enabled": false,
+            "passthrough": false,
+            "bitrate": 600,
+            "codec": "h264",
+            "videoParams": {
+                "profile": "baseline",
+                "preset": "A",
+                "height": 360
+            }
+        },
+        {
+            "trackId": "v35",
+            "enabled": false,
+            "passthrough": false,
+            "bitrate": 400,
+            "codec": "h264",
+            "videoParams": {
+                "profile": "baseline",
+                "preset": "A",
+                "height": 360
+            }
+        },
+        {
+            "trackId": "v42",
+            "enabled": false,
+            "passthrough": false,
+            "bitrate": 1500,
+            "codec": "h264",
+            "videoParams": {
+                "profile": "high",
+                "preset": "A",
+                "height": 720
+            }
+        },
+        {
+            "trackId": "v43",
+            "enabled": false,
+            "passthrough": false,
+            "bitrate": 2500,
+            "codec": "h264",
+            "videoParams": {
+                "profile": "high",
+                "preset": "A",
+                "height": 2160,
+                "skipFrame": 1
+            }
+        }
+    ]
+}

--- a/transcoder/tests/config_v.json
+++ b/transcoder/tests/config_v.json
@@ -11,7 +11,7 @@
     },
     "throttler": {
         "maxDataRate": 1.5,
-        "coldSeconds": 1,
+        "useStatsDataRate": false,
         "minThrottleWaitMs": 1
     },
     "frameDropper1": {

--- a/transcoder/utils/logger.h
+++ b/transcoder/utils/logger.h
@@ -20,6 +20,7 @@
 #define CATEGORY_RECEIVER "RECEIVER"
 #define CATEGORY_KMP "KMP"
 #define CATEGORY_HTTP_SERVER "HTTPSERVER"
+#define CATEGORY_THROTTLER "THROTTLER"
 
 void logger1(const char* category,int level,const char *fmt, ...);
 void loggerFlush();

--- a/transcoder/utils/samples_stats.c
+++ b/transcoder/utils/samples_stats.c
@@ -24,6 +24,7 @@ void sample_stats_init(samples_stats_t* pStats,AVRational basetime)
     pStats->firstTimeStamp=0;
     pStats->lastTimeStamp=0;
     pStats->lastDts=0;
+    pStats->throttleWait=0;
 }
 
 void drain(samples_stats_t* pStats,uint64_t clock)
@@ -102,12 +103,15 @@ void sample_stats_get_diagnostics(samples_stats_t *pStats,json_writer_ctx_t js)
     JSON_SERIALIZE_STRING("firstTimeStamp",pStats->firstTimeStamp>0 ? ts2str(pStats->firstTimeStamp,false): "N/A")
     JSON_SERIALIZE_STRING("lastTimeStamp",pStats->lastTimeStamp>0 ? ts2str(pStats->lastTimeStamp,false) : "N/A")
     JSON_SERIALIZE_INT64("lastDts",pStats->lastDts)
+    if(pStats->throttleWait > 0) {
+        JSON_SERIALIZE_INT64("throttle",pStats->throttleWait)
+    }
 }
 
 
 void samples_stats_log(const char* category,int level,samples_stats_t *stats,const char *prefix)
 {
-    LOGGER(category,level,"[%s] Stats: total frames: %ld total errors: %ld total time: %s (%s), clock drift %s,bitrate %.2lf Kbit/s fps=%.2lf rate=x%.2lf",
+    LOGGER(category,level,"[%s] Stats: total frames: %ld total errors: %ld total time: %s (%s), clock drift %s,bitrate %.2lf Kbit/s fps=%.2lf rate=x%.2lf throttleWait %s",
            prefix,
            stats->totalFrames,
            stats->totalErrors,
@@ -116,5 +120,6 @@ void samples_stats_log(const char* category,int level,samples_stats_t *stats,con
            pts2str(stats->clockDrift),
            ((double)stats->currentBitRate)/(1000.0),
            stats->currentFrameRate,
-           stats->currentRate)
+           stats->currentRate,
+           pts2str(stats->throttleWait))
 }

--- a/transcoder/utils/samples_stats.h
+++ b/transcoder/utils/samples_stats.h
@@ -41,6 +41,7 @@ typedef struct
     uint64_t firstTimeStamp,lastTimeStamp;
     int64_t timeStampPassed;
     int64_t clockDrift;
+    int64_t throttleWait;
 } samples_stats_t;
 
 void sample_stats_init(samples_stats_t* pStats,AVRational basetime);

--- a/transcoder/utils/throttler.c
+++ b/transcoder/utils/throttler.c
@@ -10,8 +10,8 @@
 #include "json_parser.h"
 
 static void doThrottle(float maxDataRate,
-    float coldSeconds,
-    int minThrottleWaitMs,
+    bool useStatsDataRate,
+    double minThrottleWaitMs,
     samples_stats_t *stats,
     AVRational targetFramerate);
 
@@ -19,10 +19,9 @@ int
 throttler_init(samples_stats_t *stats,throttler_t *throttler) {
     json_value_t *config = GetConfig();
     json_get_double(config,"throttler.maxDataRate",INFINITY,(double*)&throttler->maxDataRate);
-    *(bool*)&throttler->enabled = throttler->maxDataRate < INFINITY;
-    if(throttler->enabled){
-        json_get_double(config,"throttler.coldSeconds",0,(double*)&throttler->coldSeconds);
-        json_get_int(config,"throttler.minThrottleWaitMs",1,(int*)&throttler->minThrottleWaitMs);
+    if(throttler->maxDataRate < INFINITY){
+        json_get_bool(config,"throttler.useStatsDataRate",false,(bool*)&throttler->useStatsDataRate);
+        json_get_double(config,"throttler.minThrottleWaitMs",1,(double*)&throttler->minThrottleWaitMs);
         throttler->stats = stats;
     }
     return 0;
@@ -34,12 +33,14 @@ throttler_process(throttler_t *throttler,transcode_session_t *transcode_session)
         const transcode_mediaInfo_t *mediaInfo = transcode_session ? transcode_session->currentMediaInfo : NULL;
         if(mediaInfo && mediaInfo->codecParams){
             const bool isVideo = mediaInfo->codecParams->codec_type == AVMEDIA_TYPE_VIDEO;
+            // TODO: currently only AAC 'fps' is supported, MP3 and opus etc.
+            // may have a different frame allocation schemes
             const AVRational frameRate = isVideo ? mediaInfo->frameRate :
                 (AVRational){ .num = mediaInfo->codecParams->sample_rate ,
                   .den = 1024 };
 
             doThrottle(throttler->maxDataRate,
-                throttler->coldSeconds,
+                throttler->useStatsDataRate,
                 throttler->minThrottleWaitMs,
                 throttler->stats,
                 frameRate);
@@ -50,36 +51,44 @@ throttler_process(throttler_t *throttler,transcode_session_t *transcode_session)
 static
 void
 doThrottle(float maxDataRate,
-    float coldSeconds,
-    int minThrottleWaitMs,
+    bool useStatsDataRate,
+    double minThrottleWaitMs,
     samples_stats_t *stats,
     AVRational targetFramerate)
 {
 
     if(targetFramerate.den > 0 && targetFramerate.num > 0) {
-         float currentDataRate;
+         const double currentDataRate = useStatsDataRate ? stats->currentRate :
+            stats->currentFrameRate * targetFramerate.den / (float)targetFramerate.num;
 
-         samples_stats_log(CATEGORY_RECEIVER,AV_LOG_DEBUG,stats,"throttleThread-Stats");
-
-         if(stats->totalFrames * targetFramerate.den < coldSeconds * targetFramerate.num ) {
-             return;
-         }
-         // when starting up use actual number of frames received so far and
-         // not the speed at which they accumulate
-         const currentFrameRate = __MIN(stats->totalFrames,stats->currentFrameRate);
-         currentDataRate = currentFrameRate * targetFramerate.den / (float)targetFramerate.num;
+         samples_stats_log(CATEGORY_RECEIVER,AV_LOG_DEBUG,stats,"Throttle-Stats");
 
          LOGGER(CATEGORY_THROTTLER,
-            AV_LOG_DEBUG,"throttleThread. data rate current: %.3f max: %.3f",
+            AV_LOG_DEBUG,"%s. data rate current: %.3f max: %.3f",
+            __FUNCTION__,
             currentDataRate,
             maxDataRate);
 
          if(currentDataRate > maxDataRate) {
              // going to sleep for a period of time gained due to race
-             int throttleWaitUSec = (currentDataRate - maxDataRate) * 1000 * 1000; //av_rescale(1000 * 1000,targetFramerate.den,targetFramerate.num);
-             const int minThrottleWaitMs = 1;
+              int throttleWindowUs;
+              if(stats->totalFrames * targetFramerate.den < targetFramerate.num) {
+                 // during startup frame rate is not stable and usually is high
+                 // due to system delays related to various factors. therefore.
+                 // we must work with high pressures in small intervals of time.
+                 // In order to not overshoot we take smaller intervals proportional to
+                 // time passed since beginning.
+                 throttleWindowUs = av_rescale_q(1000*1000,
+                     (AVRational){stats->totalFrames,1},
+                     targetFramerate);
+              } else {
+                 throttleWindowUs = 1000 * 1000;
+              }
+             int throttleWaitUSec = (currentDataRate - maxDataRate) * throttleWindowUs;
              if(throttleWaitUSec > minThrottleWaitMs * 1000) {
-                 LOGGER(CATEGORY_THROTTLER,AV_LOG_INFO,"throttleThread. throttling %.3f ms",throttleWaitUSec / 1000.f);
+                 LOGGER(CATEGORY_THROTTLER,AV_LOG_INFO,"%s. throttling %.3f ms",
+                 __FUNCTION__,
+                 throttleWaitUSec / 1000.f);
                  stats->throttleWait += av_rescale_q(throttleWaitUSec, clockScale, standard_timebase);
                  av_usleep(throttleWaitUSec);
              }

--- a/transcoder/utils/throttler.c
+++ b/transcoder/utils/throttler.c
@@ -119,6 +119,7 @@ doThrottle(float maxDataRate,
          // going to sleep for a period of time gained due to race
          int64_t throttleWindowUs = calculateThrottleWindow(stats,targetFramerate);
          int throttleWaitUSec = (currentDataRate - maxDataRate) * throttleWindowUs;
+         throttleWaitUSec = __MIN(throttleWaitUSec, av_rescale(1000*1000,targetFramerate.den,targetFramerate.num) / maxDataRate);
          if(throttleWaitUSec > minThrottleWaitMs * 1000) {
              LOGGER(CATEGORY_THROTTLER,AV_LOG_INFO,"%s. throttling %.3f ms",
              __FUNCTION__,

--- a/transcoder/utils/throttler.c
+++ b/transcoder/utils/throttler.c
@@ -9,12 +9,18 @@
 #include "throttler.h"
 #include "json_parser.h"
 
+// forward declarations
 static void doThrottle(float maxDataRate,
-    bool useStatsDataRate,
     double minThrottleWaitMs,
     samples_stats_t *stats,
     AVRational targetFramerate);
 
+static
+bool getFrameRateFromMediaInfo(
+    const transcode_mediaInfo_t *mediaInfo,
+    AVRational *result);
+
+// api
 int
 throttler_init(samples_stats_t *stats,throttler_t *throttler) {
     json_value_t *config = GetConfig();
@@ -32,15 +38,13 @@ throttler_process(throttler_t *throttler,transcode_session_t *transcode_session)
    if(throttler && throttler->maxDataRate < INFINITY) {
         const transcode_mediaInfo_t *mediaInfo = transcode_session ? transcode_session->currentMediaInfo : NULL;
         if(mediaInfo && mediaInfo->codecParams){
-            const bool isVideo = mediaInfo->codecParams->codec_type == AVMEDIA_TYPE_VIDEO;
-            // TODO: currently only AAC 'fps' is supported, MP3 and opus etc.
-            // may have a different frame allocation schemes
-            const AVRational frameRate = isVideo ? mediaInfo->frameRate :
-                (AVRational){ .num = mediaInfo->codecParams->sample_rate ,
-                  .den = 1024 };
+            AVRational frameRate = {0};
+
+            if(!throttler->useStatsDataRate) {
+                getFrameRateFromMediaInfo(mediaInfo,&frameRate);
+            }
 
             doThrottle(throttler->maxDataRate,
-                throttler->useStatsDataRate,
                 throttler->minThrottleWaitMs,
                 throttler->stats,
                 frameRate);
@@ -48,50 +52,79 @@ throttler_process(throttler_t *throttler,transcode_session_t *transcode_session)
     }
 }
 
+// implementation:
+static
+bool
+getFrameRateFromMediaInfo(
+    const transcode_mediaInfo_t *mediaInfo,
+    AVRational *result) {
+   if(AVMEDIA_TYPE_VIDEO == mediaInfo->codecParams->codec_type){
+       *result = mediaInfo->frameRate;
+       return true;
+   }
+   else if(AV_CODEC_ID_AAC == mediaInfo->codecParams->codec_id){
+        *result = (AVRational){
+            .num = mediaInfo->codecParams->sample_rate ,
+            .den = 960 // 1024
+        };
+        return true;
+   }
+
+   LOGGER(CATEGORY_THROTTLER,
+       AV_LOG_DEBUG,"%s. unsupported (av) codec %d",
+       __FUNCTION__,
+       mediaInfo->codecParams->codec_id);
+
+   return false;
+}
+
+static
+int64_t calculateThrottleWindow(samples_stats_t *stats,AVRational targetFramerate){
+     if(targetFramerate.den == 0) {
+        if(stats->dtsPassed < 90000) {
+            return av_rescale(1000*1000,stats->dtsPassed , 90000);
+        }
+     } else if(stats->totalFrames * targetFramerate.den < targetFramerate.num) {
+         // during startup frame rate is not stable and usually is high
+         // due to system delays related to various factors. therefore.
+         // we must work with high pressures in small intervals of time.
+         // In order to not overshoot we take smaller intervals proportional to
+         // time passed since beginning.
+         return av_rescale_q(1000*1000,
+             (AVRational){stats->totalFrames,1},
+             targetFramerate);
+      }
+      return 1000 * 1000;
+}
+
 static
 void
 doThrottle(float maxDataRate,
-    bool useStatsDataRate,
     double minThrottleWaitMs,
     samples_stats_t *stats,
     AVRational targetFramerate)
 {
+     const double currentDataRate = targetFramerate.den == 0 ? stats->currentRate :
+        stats->currentFrameRate * targetFramerate.den / (float)targetFramerate.num;
 
-    if(targetFramerate.den > 0 && targetFramerate.num > 0) {
-         const double currentDataRate = useStatsDataRate ? stats->currentRate :
-            stats->currentFrameRate * targetFramerate.den / (float)targetFramerate.num;
+     samples_stats_log(CATEGORY_RECEIVER,AV_LOG_DEBUG,stats,"Throttle-Stats");
 
-         samples_stats_log(CATEGORY_RECEIVER,AV_LOG_DEBUG,stats,"Throttle-Stats");
+     LOGGER(CATEGORY_THROTTLER,
+        AV_LOG_DEBUG,"%s. data rate current: %.3f max: %.3f",
+        __FUNCTION__,
+        currentDataRate,
+        maxDataRate);
 
-         LOGGER(CATEGORY_THROTTLER,
-            AV_LOG_DEBUG,"%s. data rate current: %.3f max: %.3f",
-            __FUNCTION__,
-            currentDataRate,
-            maxDataRate);
-
-         if(currentDataRate > maxDataRate) {
-             // going to sleep for a period of time gained due to race
-              int throttleWindowUs;
-              if(stats->totalFrames * targetFramerate.den < targetFramerate.num) {
-                 // during startup frame rate is not stable and usually is high
-                 // due to system delays related to various factors. therefore.
-                 // we must work with high pressures in small intervals of time.
-                 // In order to not overshoot we take smaller intervals proportional to
-                 // time passed since beginning.
-                 throttleWindowUs = av_rescale_q(1000*1000,
-                     (AVRational){stats->totalFrames,1},
-                     targetFramerate);
-              } else {
-                 throttleWindowUs = 1000 * 1000;
-              }
-             int throttleWaitUSec = (currentDataRate - maxDataRate) * throttleWindowUs;
-             if(throttleWaitUSec > minThrottleWaitMs * 1000) {
-                 LOGGER(CATEGORY_THROTTLER,AV_LOG_INFO,"%s. throttling %.3f ms",
-                 __FUNCTION__,
-                 throttleWaitUSec / 1000.f);
-                 stats->throttleWait += av_rescale_q(throttleWaitUSec, clockScale, standard_timebase);
-                 av_usleep(throttleWaitUSec);
-             }
+     if(currentDataRate > maxDataRate) {
+         // going to sleep for a period of time gained due to race
+         int64_t throttleWindowUs = calculateThrottleWindow(stats,targetFramerate);
+         int throttleWaitUSec = (currentDataRate - maxDataRate) * throttleWindowUs;
+         if(throttleWaitUSec > minThrottleWaitMs * 1000) {
+             LOGGER(CATEGORY_THROTTLER,AV_LOG_INFO,"%s. throttling %.3f ms",
+             __FUNCTION__,
+             throttleWaitUSec / 1000.f);
+             stats->throttleWait += av_rescale_q(throttleWaitUSec, clockScale, standard_timebase);
+             av_usleep(throttleWaitUSec);
          }
-    }
+     }
 }

--- a/transcoder/utils/throttler.c
+++ b/transcoder/utils/throttler.c
@@ -1,0 +1,86 @@
+//
+//  throttler.c
+//  live_transcoder
+//
+//
+
+
+#include "../transcode/transcode_session.h"
+#include "throttler.h"
+#include "json_parser.h"
+
+static void doThrottle(float maxDataRate,
+    int coldSeconds,
+    int minThrottleWaitMs,
+    samples_stats_t *stats,
+    AVRational targetFramerate);
+
+int
+throttler_init(samples_stats_t *stats,throttler_t *throttler) {
+    json_value_t *config = GetConfig();
+    json_get_double(config,"throttler.maxDataRate",INFINITY,(double*)&throttler->maxDataRate);
+    *(bool*)&throttler->enabled = throttler->maxDataRate < INFINITY;
+    if(throttler->enabled){
+        json_get_int(config,"throttler.coldSeconds",0,(int*)&throttler->coldSeconds);
+        json_get_int(config,"throttler.minThrottleWaitMs",1,(int*)&throttler->minThrottleWaitMs);
+        throttler->stats = stats;
+    }
+    return 0;
+}
+
+void
+throttler_process(throttler_t *throttler,transcode_session_t *transcode_session) {
+   if(throttler && throttler->maxDataRate < INFINITY) {
+        const transcode_mediaInfo_t *mediaInfo = transcode_session ? transcode_session->currentMediaInfo : NULL;
+        if(mediaInfo && mediaInfo->codecParams){
+            const bool isVideo = mediaInfo->codecParams->codec_type == AVMEDIA_TYPE_VIDEO;
+            const AVRational frameRate = isVideo ? mediaInfo->frameRate :
+                (AVRational){ .num = mediaInfo->codecParams->sample_rate ,
+                  .den = 1024 };
+
+            doThrottle(throttler->maxDataRate,
+                throttler->coldSeconds,
+                throttler->minThrottleWaitMs,
+                throttler->stats,
+                frameRate);
+        }
+    }
+}
+
+static
+void
+doThrottle(float maxDataRate,
+    int coldSeconds,
+    int minThrottleWaitMs,
+    samples_stats_t *stats,
+    AVRational targetFramerate)
+{
+
+    if(targetFramerate.den > 0 && targetFramerate.num > 0) {
+         float currentDataRate;
+
+         samples_stats_log(CATEGORY_RECEIVER,AV_LOG_DEBUG,stats,"throttleThread-Stats");
+
+         if(stats->totalFrames < coldSeconds * targetFramerate.num / targetFramerate.den) {
+             return;
+         }
+
+         currentDataRate = stats->currentFrameRate * targetFramerate.den / (float)targetFramerate.num;
+
+         LOGGER(CATEGORY_THROTTLER,
+            AV_LOG_DEBUG,"throttleThread. data rate current: %.3f max: %.3f",
+            currentDataRate,
+            maxDataRate);
+
+         if(currentDataRate > maxDataRate) {
+             // going to sleep for a period of time gained due to race
+             int throttleWaitUSec = (currentDataRate - maxDataRate) * 1000 * 1000; //av_rescale(1000 * 1000,targetFramerate.den,targetFramerate.num);
+             const int minThrottleWaitMs = 1;
+             if(throttleWaitUSec > minThrottleWaitMs * 1000) {
+                 LOGGER(CATEGORY_THROTTLER,AV_LOG_INFO,"throttleThread. throttling %.3f ms",throttleWaitUSec / 1000.f);
+                 stats->throttleWait += av_rescale_q( throttleWaitUSec, clockScale, standard_timebase);
+                 av_usleep(throttleWaitUSec);
+             }
+         }
+    }
+}

--- a/transcoder/utils/throttler.c
+++ b/transcoder/utils/throttler.c
@@ -80,16 +80,16 @@ getFrameRateFromMediaInfo(
 
 static
 int64_t calculateThrottleWindow(samples_stats_t *stats,AVRational targetFramerate){
+     // during startup frame rate is not stable and usually is high
+     // due to system delays related to various factors. therefore.
+     // we must work with high pressures in small intervals of time.
+     // In order to not overshoot we take smaller intervals proportional to
+     // time passed since beginning.
      if(targetFramerate.den == 0) {
         if(stats->dtsPassed < 90000) {
             return av_rescale(1000*1000,stats->dtsPassed , 90000);
         }
      } else if(stats->totalFrames * targetFramerate.den < targetFramerate.num) {
-         // during startup frame rate is not stable and usually is high
-         // due to system delays related to various factors. therefore.
-         // we must work with high pressures in small intervals of time.
-         // In order to not overshoot we take smaller intervals proportional to
-         // time passed since beginning.
          return av_rescale_q(1000*1000,
              (AVRational){stats->totalFrames,1},
              targetFramerate);

--- a/transcoder/utils/throttler.h
+++ b/transcoder/utils/throttler.h
@@ -7,7 +7,7 @@
 typedef struct {
     const bool enabled;
     const double maxDataRate;
-    const int coldSeconds;
+    const double coldSeconds;
     const int minThrottleWaitMs;
     samples_stats_t *stats;
 } throttler_t;

--- a/transcoder/utils/throttler.h
+++ b/transcoder/utils/throttler.h
@@ -1,0 +1,20 @@
+//  live_transcoder
+//
+
+#ifndef Throttler_h
+#define Throttler_h
+
+typedef struct {
+    const bool enabled;
+    const double maxDataRate;
+    const int coldSeconds;
+    const int minThrottleWaitMs;
+    samples_stats_t *stats;
+} throttler_t;
+
+int throttler_init(samples_stats_t *stats,throttler_t *throttler);
+
+void
+throttler_process(throttler_t *throttler,transcode_session_t *session);
+
+#endif

--- a/transcoder/utils/throttler.h
+++ b/transcoder/utils/throttler.h
@@ -5,10 +5,9 @@
 #define Throttler_h
 
 typedef struct {
-    const bool enabled;
+    const bool useStatsDataRate;
     const double maxDataRate;
-    const double coldSeconds;
-    const int minThrottleWaitMs;
+    const double minThrottleWaitMs;
     samples_stats_t *stats;
 } throttler_t;
 


### PR DESCRIPTION
- add throttler.h,c
- define config throttler.maxDataRate as max limit on transcoder usage.
   * measured in times x normal fps. e.g. if maxDataRate = 2 we expect no more than twice the original throughput.
   * By default maxDataRate is set to Infinity and no data rate limit is performed.
   
- define throttler.useStatsDataRate , bool (defaults: false) as a fallback suggesting use of stream times when estimating data rate. By default, given known fps (or packet per seconds, pps)  throttler won't use dts'es as unreliable and calculate the rate from given target fps. **NOTE**: There are audio codecs like opus, where fps is not known and requires parsing packet header to determine actual number of audio samples, thus complicating the rate calculation.On the other hand, given aac is used most of the times the pps can be derived from a configuration data or assumed to be some max threshold value (e.g. 960 samples per frame)    