### PR TITLE
LIV-1206: Transcoded outputs calculate wrong values of 'created' causing packager to break and disconnect

### DIFF
--- a/transcoder/debug/file_streamer.c
+++ b/transcoder/debug/file_streamer.c
@@ -109,6 +109,7 @@ void* thread_stream_from_file(void *vargp)
         AVStream *in_stream=ifmt_ctx->streams[packet.stream_index];
 
         av_packet_rescale_ts(&packet,in_stream->time_base, standard_timebase);
+        packet.pos=createTime +packet.dts;
         if(jumpOffsetSec != 0 ) {
             const auto jumpOffset = jumpOffsetSec * standard_timebase.den;
             if(AV_NOPTS_VALUE == jumpAtTimestamp) {
@@ -124,7 +125,7 @@ void* thread_stream_from_file(void *vargp)
         }
         packet.pts+=cumulativeDuration;
         packet.dts+=cumulativeDuration;
-        packet.pos=createTime +packet.dts;
+
         if (duration!=-1) {
             if (packet.dts>=duration) {
                 LOGGER(CATEGORY_DEFAULT,AV_LOG_INFO,"Duration exceeded %s>=%s, terminating!",pts2str(packet.dts),pts2str(duration));

--- a/transcoder/utils/time_estimator.c
+++ b/transcoder/utils/time_estimator.c
@@ -38,8 +38,12 @@ uint64_t clock_estimator_get_clock(clock_estimator_t *fifo,int64_t dts)
     int64_t clock=0;
     for (int64_t runner=fifo->framesFifoHead;runner>=fifo->framesFifoTail;runner--) {
         clock_estimator_sample_t* sample=&(fifo->samples[runner %  TIME_ESTIMATOR_FIFO_SIZE]);
-        int64_t runnerdistance=llabs(sample->dts);
-        //LOGGER(CATEGORY_CLOCK_ESTIMATOR,AV_LOG_DEBUG,"runnerdistance  %ld distance %ld",runnerdistance,distance);
+        int64_t runnerdistance=llabs(dts - sample->dts);
+        LOGGER(CATEGORY_CLOCK_ESTIMATOR,AV_LOG_DEBUG,"runnerdistance  %ld distance %ld dts %s cur_dts %s",
+            runnerdistance,
+            distance,
+            pts2str(dts),
+            pts2str(sample->dts));
         if (runnerdistance<distance) {
             clock= dts - sample->dts + sample->clock;
             distance=runnerdistance;


### PR DESCRIPTION
 * use abs(dts - sample.dts) as min function
* fix file_streamer.c created time during ts jump