### PR TITLE
Prevent GPU over utilization in case of mis-configured streams with fps not set

### DIFF
--- a/transcoder/utils/throttler.h
+++ b/transcoder/utils/throttler.h
@@ -8,6 +8,8 @@ typedef struct {
     const bool useStatsDataRate;
     const double maxDataRate;
     const double minThrottleWaitMs;
+    const int defaultFramerate;
+    const int defaultSamplingRate;
     samples_stats_t *stats;
 } throttler_t;
 


### PR DESCRIPTION
Currently, only valid fps values trigger throttler action. Badly formed streams are just as easily can cause GPU over utilization, therefore:
- add default fps for video and sampling rate for audio to limit throttler when no actual fps is available