### PR TITLE
npp resize filter fails to initialize with a (h264_)cuvid decoder

### DIFF
--- a/transcoder/debug/file_streamer.c
+++ b/transcoder/debug/file_streamer.c
@@ -18,7 +18,7 @@ void* thread_stream_from_file(void *vargp)
     int oldLevel= get_log_level(NULL);
     int64_t jumpAtTimestamp = AV_NOPTS_VALUE;
 
-    log_init(AV_LOG_WARNING);
+    log_init(AV_LOG_INFO);
     int ret = avformat_open_input(&ifmt_ctx, args->source_file_name, NULL, NULL);
     if (ret < 0) {
         LOGGER(CATEGORY_DEFAULT,AV_LOG_FATAL,"Unable to open input %s %d (%s)",args->source_file_name,ret,av_err2str(ret));

--- a/transcoder/tests/config_v.json
+++ b/transcoder/tests/config_v.json
@@ -1,6 +1,6 @@
 {
     "input": {
-        "file": "/media/worng_order_video_only.mp4",
+        "file": "/media/lala_artifact.mp4",
         "realTime": false,
         "activeStream": 0,
         "xduration": 9000000,

--- a/transcoder/transcode/transcode_codec.h
+++ b/transcoder/transcode/transcode_codec.h
@@ -10,12 +10,10 @@
 #define TranscoderEncoder_h
 
 #include <stdio.h>
-#include "transcode_filter.h"
 #include "transcode_session_output.h"
 #include "samples_stats.h"
 
-typedef struct
-{
+typedef struct {
     char name[256];
     AVBufferRef *hw_device_ctx,*hw_frames_ctx;
     AVCodec* codec;
@@ -25,6 +23,9 @@ typedef struct
     samples_stats_t inStats,outStats;
 
 } transcode_codec_t;
+
+#include "transcode_filter.h"
+
 
 int transcode_codec_init(transcode_codec_t * pContext);
 

--- a/transcoder/transcode/transcode_filter.h
+++ b/transcoder/transcode/transcode_filter.h
@@ -21,7 +21,7 @@ typedef  struct
     uint64_t totalInErrors, totalOutErrors;
 } transcode_filter_t;
 
-int transcode_filter_init( transcode_filter_t *pFilter, AVCodecContext *dec_ctx,const char *filters_descr);
+int transcode_filter_init( transcode_filter_t *pFilter,transcode_codec_t *pDecoderContext,const char *filters_descr);
 int transcode_filter_send_frame( transcode_filter_t *pFilter,const AVFrame* pInFrame);
 int transcode_filter_receive_frame( transcode_filter_t *pFilter,struct AVFrame* pOutFrame);
 int transcode_filter_close( transcode_filter_t *pFilter);

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -219,7 +219,7 @@ transcode_filter_t* GetFilter(transcode_session_t* pContext,transcode_session_ou
     }
     if ( pOutput->filterId==-1) {
         pFilter=&pContext->filter[pContext->filters];
-        int ret=transcode_filter_init(pFilter,pDecoderContext->ctx,filterConfig);
+        int ret=transcode_filter_init(pFilter,pDecoderContext,filterConfig);
         if (ret<0) {
             LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_ERROR,"Output %s - Cannot create filter %s",pOutput->track_id,filterConfig);
             return NULL;


### PR DESCRIPTION
- fix passing hw_frames_ctx to a filter
- (re) add support for NV cuvid decoder (for testing purposes) config path: engine.useCuvidDecoder: false