### PR TITLE
ngx-mpegts: drop corrupt PES packets

### DIFF
--- a/nginx-mpegts-module/src/ngx_ts_stream.h
+++ b/nginx-mpegts-module/src/ngx_ts_stream.h
@@ -60,6 +60,7 @@ typedef struct {
     unsigned                      ptsf:1;
     unsigned                      rand:1;
     unsigned                      video:1;
+    unsigned                      corrupt:1;
     ngx_ts_bufs_t                 bufs;  /* ES */
 } ngx_ts_es_t;
 


### PR DESCRIPTION
when streaming with SRT some mpegts packets may drop, these errors are
currently silently ignored.
the fix is to use only payload-unit-start-indicator to split the PES
packets, and validate the resulting size against the len stated in the
PES header.
drop the packet also in case of continuity counter mismatch.