### PR TITLE
ngx-rtmp-kmp: sync audio frames timestamps

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -124,6 +124,7 @@ ngx_kmp_out_track_init_conf(ngx_kmp_out_track_conf_t *conf)
     conf->buffer_bin_count = NGX_CONF_UNSET_UINT;
     conf->mem_high_watermark = NGX_CONF_UNSET_UINT;
     conf->mem_low_watermark = NGX_CONF_UNSET_UINT;
+    conf->audio_sync_margin = NGX_CONF_UNSET_MSEC;
     conf->flush_timeout = NGX_CONF_UNSET_MSEC;
     conf->keepalive_interval = NGX_CONF_UNSET_MSEC;
     conf->log_frames = NGX_CONF_UNSET_UINT;
@@ -197,6 +198,9 @@ ngx_kmp_out_track_merge_conf(ngx_conf_t *cf, ngx_kmp_out_track_conf_t *conf,
             prev->mem_limit[media_type],
             ngx_kmp_out_track_default_mem_limit[media_type]);
     }
+
+    ngx_conf_merge_msec_value(conf->audio_sync_margin,
+                              prev->audio_sync_margin, 2);
 
     ngx_conf_merge_msec_value(conf->flush_timeout, prev->flush_timeout, 1000);
 

--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.h
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.h
@@ -30,6 +30,7 @@ typedef struct {
     size_t           buffer_size[KMP_MEDIA_COUNT];
     size_t           mem_limit[KMP_MEDIA_COUNT];
     ngx_lba_t       *lba[KMP_MEDIA_COUNT];
+    ngx_msec_t       audio_sync_margin;
 
     ngx_msec_t       flush_timeout;
     ngx_msec_t       keepalive_interval;

--- a/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
+++ b/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
@@ -9,7 +9,7 @@
 #endif // VOD_HAVE_OPENSSL_EVP
 
 // from ffmpeg mpegtsenc
-#define DEFAULT_PES_HEADER_FREQ 16
+#define DEFAULT_PES_HEADER_FREQ 8
 #define DEFAULT_PES_PAYLOAD_SIZE ((DEFAULT_PES_HEADER_FREQ - 1) * 184 + 170)
 
 // typedefs

--- a/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
+++ b/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
@@ -9,7 +9,7 @@
 #endif // VOD_HAVE_OPENSSL_EVP
 
 // from ffmpeg mpegtsenc
-#define DEFAULT_PES_HEADER_FREQ 8
+#define DEFAULT_PES_HEADER_FREQ 3
 #define DEFAULT_PES_PAYLOAD_SIZE ((DEFAULT_PES_HEADER_FREQ - 1) * 184 + 170)
 
 // typedefs

--- a/nginx-rtmp-kmp-module/README.md
+++ b/nginx-rtmp-kmp-module/README.md
@@ -242,6 +242,16 @@ A large value can be more efficient, but increases the latency (a buffer is sent
 Sets the maximum total size of the buffers used to send audio data to the upstream server.
 If the limit is hit, the module drops the RTMP connection.
 
+#### kmp_audio_sync_margin
+* **syntax**: `kmp_audio_sync_margin msec;`
+* **default**: `2ms`
+* **context**: `rtmp`, `server`, `application`
+
+Sets the maximum correction value applied to the timestamps of audio frames.
+In order to overcome loss of precision in audio timestamps (RTMP uses millis timescale),
+the module extrapolates the audio timestamps using the actual duration of the audio frames.
+Frames that have a timestamp within kmp_audio_sync_margin from the extrapolated value, will use the extrapolated value.
+
 #### kmp_flush_timeout
 * **syntax**: `kmp_flush_timeout msec;`
 * **default**: `1s`

--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_module.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_module.c
@@ -214,6 +214,13 @@ static ngx_command_t  ngx_rtmp_kmp_commands[] = {
       offsetof(ngx_rtmp_kmp_app_conf_t, t.mem_limit[KMP_MEDIA_AUDIO]),
       NULL },
 
+    { ngx_string("kmp_audio_sync_margin"),
+      NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      NGX_RTMP_APP_CONF_OFFSET,
+      offsetof(ngx_rtmp_kmp_app_conf_t, t.audio_sync_margin),
+      NULL },
+
     { ngx_string("kmp_flush_timeout"),
       NGX_RTMP_MAIN_CONF|NGX_RTMP_SRV_CONF|NGX_RTMP_APP_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_msec_slot,

--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
@@ -248,6 +248,12 @@ ngx_rtmp_kmp_track_sync_audio(ngx_kmp_out_track_t *track,
     } else {
         ctx->audio_base_dts = frame->f.dts;
         ctx->audio_samples = 0;
+
+        //TODO: use only in debug builds!
+        ngx_log_error(NGX_LOG_INFO, &track->log, 0,
+            "ngx_rtmp_kmp_track_sync_audio: "
+            "reset audio_base_dts frame_dts  %L est_dts %L margin %L",
+            frame->f.dts, est_dts, margin);
     }
 
     /* TODO: identify short frames (960) from extra data */


### PR DESCRIPTION
to compensate for loss of precision due to RTMP timescale, causing ticking noises in Apple players