### PR TITLE
revert test and debug changes added to erank branch

### DIFF
--- a/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
+++ b/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
@@ -9,7 +9,7 @@
 #endif // VOD_HAVE_OPENSSL_EVP
 
 // from ffmpeg mpegtsenc
-#define DEFAULT_PES_HEADER_FREQ 3
+#define DEFAULT_PES_HEADER_FREQ 8
 #define DEFAULT_PES_PAYLOAD_SIZE ((DEFAULT_PES_HEADER_FREQ - 1) * 184 + 170)
 
 // typedefs

--- a/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
+++ b/nginx-pckg-module/src/media/mpegts/mpegts_muxer.c
@@ -9,7 +9,7 @@
 #endif // VOD_HAVE_OPENSSL_EVP
 
 // from ffmpeg mpegtsenc
-#define DEFAULT_PES_HEADER_FREQ 8
+#define DEFAULT_PES_HEADER_FREQ 16
 #define DEFAULT_PES_PAYLOAD_SIZE ((DEFAULT_PES_HEADER_FREQ - 1) * 184 + 170)
 
 // typedefs

--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
@@ -248,12 +248,6 @@ ngx_rtmp_kmp_track_sync_audio(ngx_kmp_out_track_t *track,
     } else {
         ctx->audio_base_dts = frame->f.dts;
         ctx->audio_samples = 0;
-
-        //TODO: use only in debug builds!
-        ngx_log_error(NGX_LOG_INFO, &track->log, 0,
-            "ngx_rtmp_kmp_track_sync_audio: "
-            "reset audio_base_dts frame_dts  %L est_dts %L margin %L",
-            frame->f.dts, est_dts, margin);
     }
 
     /* TODO: identify short frames (960) from extra data */


### PR DESCRIPTION
- set DEFAULT_PES_HEADER_FREQ back to 8
- remove debug log line in ngx_rtmp_kmp_track_sync_audio