### PR TITLE
SUP-43286: Kaltura Event recordings cannot be imported to Adobe Premiere Pro due to "Unsupported Compression Type"

### DIFF
--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -496,26 +496,36 @@ codec_config_mp4a_config_parse(
 
     if (reader.stream.eof_reached)
     {
-        vod_log_error(VOD_LOG_ERR, log, 0,
-            "codec_config_mp4a_config_parse: failed to read all required audio extra data fields");
-        return VOD_BAD_DATA;
+        goto error;
     }
 
     if (result->object_type == AOT_SBR || result->object_type == AOT_PS )
     {
+        uint8_t ext_sample_rate_index = bit_read_stream_get(&reader, 4);
+        if (ext_sample_rate_index == 0x0f)
+            bit_read_stream_get(&reader, 24);
+
+        if (reader.stream.eof_reached)
+        {
+           goto error;
+        }
+
         result->object_type = bit_read_stream_get(&reader, 5);
         if (result->object_type == AOT_ESCAPE)
             result->object_type = 32 + bit_read_stream_get(&reader, 6);
 
         if (reader.stream.eof_reached)
         {
-            vod_log_error(VOD_LOG_ERR, log, 0,
-                "codec_config_mp4a_config_parse: failed to read all required audio extra data fields");
-            return VOD_BAD_DATA;
+            goto error;
         }
     }
 
     return VOD_OK;
+error:
+
+    vod_log_error(VOD_LOG_ERR, log, 0,
+        "codec_config_mp4a_config_parse: failed to read all required audio extra data fields");
+    return VOD_BAD_DATA;
 }
 
 uint32_t

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -479,6 +479,7 @@ codec_config_mp4a_config_parse(
     mp4a_config_t* result)
 {
     bit_reader_state_t reader;
+    uint8_t ext_sample_rate_index;
 
     vod_log_buffer(VOD_LOG_DEBUG_LEVEL, log, 0, "codec_config_mp4a_config_parse: extra data ", extra_data->data, extra_data->len);
 
@@ -501,7 +502,7 @@ codec_config_mp4a_config_parse(
 
     if (result->object_type == AOT_SBR || result->object_type == AOT_PS )
     {
-        uint8_t ext_sample_rate_index = bit_read_stream_get(&reader, 4);
+        ext_sample_rate_index = bit_read_stream_get(&reader, 4);
         if (ext_sample_rate_index == 0x0f)
             bit_read_stream_get(&reader, 24);
 

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -517,7 +517,9 @@ codec_config_mp4a_config_parse(
 
         result->object_type = bit_read_stream_get(&reader, 5);
         if (result->object_type == AOT_ESCAPE)
+        {
             result->object_type = 32 + bit_read_stream_get(&reader, 6);
+        }
 
         if (reader.stream.eof_reached)
         {

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -504,11 +504,13 @@ codec_config_mp4a_config_parse(
     {
         ext_sample_rate_index = bit_read_stream_get(&reader, 4);
         if (ext_sample_rate_index == 0x0f)
+        {
             bit_read_stream_get(&reader, 24);
+        }
 
         if (reader.stream.eof_reached)
         {
-           goto error;
+            goto error;
         }
 
         result->object_type = bit_read_stream_get(&reader, 5);

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -521,10 +521,12 @@ codec_config_mp4a_config_parse(
     }
 
     return VOD_OK;
+
 error:
 
     vod_log_error(VOD_LOG_ERR, log, 0,
         "codec_config_mp4a_config_parse: failed to read all required audio extra data fields");
+
     return VOD_BAD_DATA;
 }
 

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -478,7 +478,7 @@ codec_config_mp4a_config_parse(
     vod_str_t* extra_data,
     mp4a_config_t* result)
 {
-    bit_reader_state_t reader;
+    bit_reader_state_t reader, temp_reader;
     uint8_t ext_sample_rate_index;
 
     vod_log_buffer(VOD_LOG_DEBUG_LEVEL, log, 0, "codec_config_mp4a_config_parse: extra data ", extra_data->data, extra_data->len);
@@ -500,7 +500,9 @@ codec_config_mp4a_config_parse(
         goto error;
     }
 
-    if (result->object_type == AOT_SBR || result->object_type == AOT_PS)
+temp_reader = reader;
+if (result->object_type == AOT_SBR || (result->object_type == AOT_PS &&
+    !(bit_read_stream_get(&temp_reader, 3) & 0x03 && !(bit_read_stream_get(&temp_reader, 9) & 0x3f))))
     {
         ext_sample_rate_index = bit_read_stream_get(&reader, 4);
         if (ext_sample_rate_index == 0x0f)

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -500,7 +500,7 @@ codec_config_mp4a_config_parse(
         goto error;
     }
 
-    if (result->object_type == AOT_SBR || result->object_type == AOT_PS )
+    if (result->object_type == AOT_SBR || result->object_type == AOT_PS)
     {
         ext_sample_rate_index = bit_read_stream_get(&reader, 4);
         if (ext_sample_rate_index == 0x0f)

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -500,9 +500,9 @@ codec_config_mp4a_config_parse(
         goto error;
     }
 
-temp_reader = reader;
-if (result->object_type == AOT_SBR || (result->object_type == AOT_PS &&
-    !(bit_read_stream_get(&temp_reader, 3) & 0x03 && !(bit_read_stream_get(&temp_reader, 9) & 0x3f))))
+    temp_reader = reader;
+    if (result->object_type == AOT_SBR || (result->object_type == AOT_PS &&
+        !(bit_read_stream_get(&temp_reader, 3) & 0x03 && !(bit_read_stream_get(&temp_reader, 9) & 0x3f))))
     {
         ext_sample_rate_index = bit_read_stream_get(&reader, 4);
         if (ext_sample_rate_index == 0x0f)

--- a/nginx-pckg-module/src/media/codec_config.c
+++ b/nginx-pckg-module/src/media/codec_config.c
@@ -10,6 +10,10 @@
 
 #define AOT_ESCAPE (31)
 
+#define AOT_SBR (5)
+
+#define AOT_PS (29)
+
 #define HVCC_HEADER_SIZE (22)
 
 
@@ -495,6 +499,20 @@ codec_config_mp4a_config_parse(
         vod_log_error(VOD_LOG_ERR, log, 0,
             "codec_config_mp4a_config_parse: failed to read all required audio extra data fields");
         return VOD_BAD_DATA;
+    }
+
+    if (result->object_type == AOT_SBR || result->object_type == AOT_PS )
+    {
+        result->object_type = bit_read_stream_get(&reader, 5);
+        if (result->object_type == AOT_ESCAPE)
+            result->object_type = 32 + bit_read_stream_get(&reader, 6);
+
+        if (reader.stream.eof_reached)
+        {
+            vod_log_error(VOD_LOG_ERR, log, 0,
+                "codec_config_mp4a_config_parse: failed to read all required audio extra data fields");
+            return VOD_BAD_DATA;
+        }
     }
 
     return VOD_OK;

--- a/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
+++ b/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
@@ -42,15 +42,11 @@ adts_encoder_set_media_info(
     adts_frame_header_set_channel_configuration(state->header, codec_config->channel_config);
     adts_frame_header_set_adts_buffer_fullness(state->header, 0x7ff);
 
-#if (VOD_DEBUG)
-
     vod_log_debug3(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
             "adts_encoder_set_media_info: mp4a object_type: %D sample_rate_index: %D channel_config: %D",
             codec_config->object_type,
             codec_config->sample_rate_index,
             codec_config->channel_config);
-
-#endif
 
     return VOD_OK;
 }

--- a/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
+++ b/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
@@ -44,7 +44,7 @@ adts_encoder_set_media_info(
 
 #if (VOD_DEBUG)
 
-    ngx_log_error(NGX_LOG_INFO, context->request_context->log, 0,
+    vod_log_debug3(VOD_LOG_DEBUG_LEVEL, context->request_context->log, 0,
             "adts_encoder_set_media_info: mp4a object_type: %D sample_rate_index: %D channel_config: %D",
             codec_config->object_type,
             codec_config->sample_rate_index,

--- a/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
+++ b/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
@@ -24,6 +24,7 @@ adts_encoder_set_media_info(
 {
     adts_encoder_state_t* state = get_context(context);
     mp4a_config_t* codec_config = &media_info->u.audio.codec_config;
+    request_context_t *request_context = context->request_context;
 
     if (context->request_context->simulation_only)
     {
@@ -41,6 +42,13 @@ adts_encoder_set_media_info(
     adts_frame_header_set_sample_rate_index(state->header, codec_config->sample_rate_index);
     adts_frame_header_set_channel_configuration(state->header, codec_config->channel_config);
     adts_frame_header_set_adts_buffer_fullness(state->header, 0x7ff);
+
+    ngx_log_error(NGX_LOG_INFO, &request_context->log, 0,
+            "adts_encoder_set_media_info: mp4a object_type: %D sample_rate_index: %D channel_config: %D",
+            codec_config->object_type,
+            codec_config->sample_rate_index,
+            codec_config->channel_config);
+
 
     return VOD_OK;
 }

--- a/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
+++ b/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
@@ -24,7 +24,6 @@ adts_encoder_set_media_info(
 {
     adts_encoder_state_t* state = get_context(context);
     mp4a_config_t* codec_config = &media_info->u.audio.codec_config;
-    request_context_t *request_context = context->request_context;
 
     if (context->request_context->simulation_only)
     {
@@ -43,12 +42,15 @@ adts_encoder_set_media_info(
     adts_frame_header_set_channel_configuration(state->header, codec_config->channel_config);
     adts_frame_header_set_adts_buffer_fullness(state->header, 0x7ff);
 
-    ngx_log_error(NGX_LOG_INFO, request_context->log, 0,
+#if (VOD_DEBUG)
+
+    ngx_log_error(NGX_LOG_INFO, context->request_context->log, 0,
             "adts_encoder_set_media_info: mp4a object_type: %D sample_rate_index: %D channel_config: %D",
             codec_config->object_type,
             codec_config->sample_rate_index,
             codec_config->channel_config);
 
+#endif
 
     return VOD_OK;
 }

--- a/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
+++ b/nginx-pckg-module/src/media/mpegts/adts_encoder_filter.c
@@ -43,7 +43,7 @@ adts_encoder_set_media_info(
     adts_frame_header_set_channel_configuration(state->header, codec_config->channel_config);
     adts_frame_header_set_adts_buffer_fullness(state->header, 0x7ff);
 
-    ngx_log_error(NGX_LOG_INFO, &request_context->log, 0,
+    ngx_log_error(NGX_LOG_INFO, request_context->log, 0,
             "adts_encoder_set_media_info: mp4a object_type: %D sample_rate_index: %D channel_config: %D",
             codec_config->object_type,
             codec_config->sample_rate_index,


### PR DESCRIPTION
handle HE-AAC audio config in packager module.

**description::**
Bad HLS/ts stream was generated for source flavor (transcoded streams were re-encoded to AAC-LC) due to mp4a config insufficient parsing.
For the same reason, recording generated from mpegts chunks contained bad mp4a config.  As a result, picky media players such as quicktime player based on CoreAudio, refused to play back recorded files 
