### PR TITLE
PSVAMB-69845: Buffering and Errors on Live Streams During Extended Streaming-Time Test

### DIFF
--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
@@ -314,10 +314,6 @@ ngx_rtmp_kmp_track_init_frame(ngx_kmp_out_track_t *track,
 
             has_pts_delay = 1;
 
-            if (packet_type == NGX_RTMP_AVC_SEQUENCE_HEADER) {
-                *sequence_header = 1;
-            }
-
         } else  {
 
             frame_info &= ~NGX_RTMP_EXT_HEADER_MASK;

--- a/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
+++ b/nginx-rtmp-kmp-module/src/ngx_rtmp_kmp_track.c
@@ -314,6 +314,10 @@ ngx_rtmp_kmp_track_init_frame(ngx_kmp_out_track_t *track,
 
             has_pts_delay = 1;
 
+            if (packet_type == NGX_RTMP_AVC_SEQUENCE_HEADER) {
+                has_pts_delay = 0;
+            }
+
         } else  {
 
             frame_info &= ~NGX_RTMP_EXT_HEADER_MASK;


### PR DESCRIPTION
rollback queueing media info event upon detecting AVC sequence header.
(https://github.com/kaltura/media-framework/commit/b05730d331887c5dbed9a57d2a600d20167e050a)

This is because transcoder will break if new media info does not match previous one.

NOTE: while fixing some of the cases of encoder state change, more substantial changes e.g. resolution change will eventually cause decoder/filter/encoder graph to break