### PR TITLE
PSVAMB-69845: [Dreamforce 2024][ESTT] Buffering and Errors on Live Streams During Extended Streaming-Time Test

### DIFF
--- a/nginx-kmp-out-module/src/ngx_kmp_out_track.c
+++ b/nginx-kmp-out-module/src/ngx_kmp_out_track.c
@@ -1209,6 +1209,61 @@ ngx_kmp_out_track_write(ngx_kmp_out_track_t *track, u_char *data,
     return ngx_kmp_out_track_write_chain(track, &in, data);
 }
 
+static ngx_int_t
+ngx_kmp_out_track_log_media_info(ngx_kmp_out_track_t *track)
+{
+     u_char              *buf = NULL,
+                         *p;
+
+    if(track->extra_data.len > 0)
+    {
+        buf = ngx_pnalloc(track->pool, 2 * track->extra_data.len + 1);
+        if(!buf)
+        {
+            ngx_log_error(NGX_LOG_ERR, &track->log, 0,
+              "ngx_kmp_out_track_log_media_info:"
+              "failed to allocate buffer for extra data size %uD",
+              2 * track->extra_data.len + 1);
+            return NGX_ERROR;
+        }
+
+        p = ngx_hex_dump(buf, track->extra_data.data, track->extra_data.len);
+        *p = 0;
+    }
+
+    ngx_log_error(NGX_LOG_INFO, &track->log, 0,
+       "ngx_kmp_out_track_log_media_info:"
+       " media_type: %uD codec_id:   %uD"
+       " timescale:  %uD bitrate:    %uD"
+       " extra_data: %s",
+       track->media_info.media_type, track->media_info.codec_id,
+       track->media_info.timescale,  track->media_info.bitrate,  buf);
+    switch(track->media_info.media_type)
+    {
+       case KMP_MEDIA_VIDEO:
+            ngx_log_error(NGX_LOG_INFO, &track->log, 0,
+                  "ngx_kmp_out_track_log_media_info: video"
+                  " width: %uD height: %uD frame_rate: %uD/%uD cea_captions: %s",
+                  track->media_info.u.video.width, track->media_info.u.video.height,
+                  track->media_info.u.video.frame_rate.num, track->media_info.u.video.frame_rate.denom,
+                  track->media_info.u.video.cea_captions ? "true" : "false");
+            break;
+       case KMP_MEDIA_AUDIO:
+            ngx_log_error(NGX_LOG_INFO, &track->log, 0,
+                  "ngx_kmp_out_track_write_media_info: audio"
+                  " channels: %uD bits_per_sample: %uD sample_rate: %uD channel_layout: %uD",
+                 track->media_info.u.audio.channels, track->media_info.u.audio.bits_per_sample,
+                 track->media_info.u.audio.sample_rate, track->media_info.u.audio.channel_layout);
+            break;
+    };
+
+    if(buf)
+    {
+        ngx_pfree(track->pool, buf);
+    }
+
+    return NGX_OK;
+}
 
 ngx_int_t
 ngx_kmp_out_track_write_media_info(ngx_kmp_out_track_t *track)
@@ -1238,9 +1293,10 @@ ngx_kmp_out_track_write_media_info(ngx_kmp_out_track_t *track)
         return NGX_ERROR;
     }
 
+    ngx_kmp_out_track_log_media_info(track);
+
     return NGX_OK;
 }
-
 
 static void
 ngx_kmp_out_track_chain_md5_hex(u_char dst[32], ngx_chain_t *in, u_char *p)

--- a/nginx-rtmp-module/src/ngx_rtmp_codec_module.c
+++ b/nginx-rtmp-module/src/ngx_rtmp_codec_module.c
@@ -1456,6 +1456,7 @@ ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf)
     ngx_rtmp_core_main_conf_t          *cmcf;
     ngx_rtmp_handler_pt                *h;
     ngx_rtmp_amf_handler_t             *ch;
+    ngx_uint_t                          nelts;
 
     cmcf = ngx_rtmp_conf_get_module_main_conf(cf, ngx_rtmp_core_module);
 
@@ -1464,11 +1465,21 @@ ngx_rtmp_codec_postconfiguration(ngx_conf_t *cf)
         return NGX_ERROR;
     }
 
+    nelts = cmcf->events[NGX_RTMP_MSG_AUDIO].nelts;
+    for(;nelts > 1;nelts--, h--) {
+       *h =  h[-1];
+    }
+
     *h = ngx_rtmp_codec_av;
 
     h = ngx_array_push(&cmcf->events[NGX_RTMP_MSG_VIDEO]);
     if (h == NULL) {
         return NGX_ERROR;
+    }
+
+    nelts = cmcf->events[NGX_RTMP_MSG_VIDEO].nelts;
+    for(;nelts > 1;nelts--, h--) {
+       *h =  h[-1];
     }
 
     *h = ngx_rtmp_codec_av;

--- a/transcoder/KMP/KMP.c
+++ b/transcoder/KMP/KMP.c
@@ -818,7 +818,7 @@ int KMP_log_mediainfo(KMP_session_t *context,
             params->bits_per_coded_sample,
             params->channels,
             params->channel_layout,
-            params->bit_rate / 1000.0, transcodeMediaInfo->timeScale.num, transcodeMediaInfo->timeScale.den,
+            params->bit_rate / 1024.0, transcodeMediaInfo->timeScale.num, transcodeMediaInfo->timeScale.den,
             ex);
     }
     else if (params->codec_type == AVMEDIA_TYPE_VIDEO) {
@@ -833,7 +833,7 @@ int KMP_log_mediainfo(KMP_session_t *context,
             params->width,
             params->height,
             transcodeMediaInfo->frameRate.num, transcodeMediaInfo->frameRate.den,
-            params->bit_rate / 1000.0, transcodeMediaInfo->timeScale.num, transcodeMediaInfo->timeScale.den,
+            params->bit_rate / 1024.0, transcodeMediaInfo->timeScale.num, transcodeMediaInfo->timeScale.den,
             transcodeMediaInfo->closed_captions ? "yes" : "no",
             ex);
     }

--- a/transcoder/KMP/KMP.h
+++ b/transcoder/KMP/KMP.h
@@ -50,6 +50,8 @@ int KMP_send_ack( KMP_session_t *context,kmp_frame_position_t *cur_pos);
 
 int KMP_close( KMP_session_t *context);
 
+int KMP_log_mediainfo(KMP_session_t *context, const char *category,int level,     transcode_mediaInfo_t* mediaInfo);
+
 
 int KMP_listen( KMP_session_t *context);
 int KMP_accept( KMP_session_t *context, KMP_session_t *client);

--- a/transcoder/common/json_parser.h
+++ b/transcoder/common/json_parser.h
@@ -116,7 +116,7 @@ typedef struct {
 
 #define JSON_SERIALIZE_STRING(key,value)  ADD_COMMA() JSON_WRITE("\"%s\": \"%s\"",key,value); js->shouldAddComma=true;
 #define JSON_SERIALIZE_INT(key,value)     ADD_COMMA() JSON_WRITE("\"%s\": %d",key,value); js->shouldAddComma=true;
-#define JSON_SERIALIZE_INT64(key,value)   ADD_COMMA() JSON_WRITE("\"%s\": %lld",key,value); js->shouldAddComma=true;
+#define JSON_SERIALIZE_INT64(key,value)   ADD_COMMA() JSON_WRITE("\"%s\": %ld",key,value); js->shouldAddComma=true;
 #define JSON_SERIALIZE_BOOL(key,value)    ADD_COMMA() JSON_WRITE("\"%s\": %s",key,value ? "true" : "false"); js->shouldAddComma=true;
 #define JSON_SERIALIZE_DOUBLE(key,value)  ADD_COMMA() JSON_WRITE("\"%s\": %.2lf",key,value); js->shouldAddComma=true;
 

--- a/transcoder/common/json_parser.h
+++ b/transcoder/common/json_parser.h
@@ -115,8 +115,8 @@ typedef struct {
 #define JSON_SERIALIZE_ARRAY_END()        JSON_WRITE("]"); js->shouldAddComma=true;
 
 #define JSON_SERIALIZE_STRING(key,value)  ADD_COMMA() JSON_WRITE("\"%s\": \"%s\"",key,value); js->shouldAddComma=true;
-#define JSON_SERIALIZE_INT(key,value)     ADD_COMMA() JSON_WRITE("\"%s\": %d",key,value); js->shouldAddComma=true;
-#define JSON_SERIALIZE_INT64(key,value)   ADD_COMMA() JSON_WRITE("\"%s\": %ld",key,value); js->shouldAddComma=true;
+#define JSON_SERIALIZE_INT(key,value)     ADD_COMMA() JSON_WRITE("\"%s\": %d",key,(int)value); js->shouldAddComma=true;
+#define JSON_SERIALIZE_INT64(key,value)   ADD_COMMA() JSON_WRITE("\"%s\": %ld",key,(int64_t)value); js->shouldAddComma=true;
 #define JSON_SERIALIZE_BOOL(key,value)    ADD_COMMA() JSON_WRITE("\"%s\": %s",key,value ? "true" : "false"); js->shouldAddComma=true;
 #define JSON_SERIALIZE_DOUBLE(key,value)  ADD_COMMA() JSON_WRITE("\"%s\": %.2lf",key,value); js->shouldAddComma=true;
 

--- a/transcoder/debug/file_streamer.c
+++ b/transcoder/debug/file_streamer.c
@@ -57,6 +57,10 @@ void* thread_stream_from_file(void *vargp)
 
     json_get_int64(GetConfig(),"input.hiccupIntervalSec",0,&hiccupIntervalSec);
 
+    int64_t resendMediaInfoIntervalSec;
+    json_get_int64(GetConfig(),"input.resendMediaInfoIntervalSec",10,&resendMediaInfoIntervalSec);
+
+
     AVPacket packet;
     av_init_packet(&packet);
 
@@ -94,7 +98,11 @@ void* thread_stream_from_file(void *vargp)
     int64_t start_time=av_gettime_relative(),
             hiccup_duration =  hiccupDurationSec * 1000 * 1000,
             hiccup_interval = hiccupIntervalSec * 1000 * 1000,
-            next_hiccup = start_time + hiccup_interval;
+            next_hiccup = start_time + hiccup_interval,
+            resendMediaInfoInterval = resendMediaInfoIntervalSec * 1000 * 1000,
+            nextSentMediaInfoTime = av_gettime_relative() + resendMediaInfoInterval;
+
+    uint64_t frame_id_ack = createTime - 1;
 
     samples_stats_t stats;
     sample_stats_init(&stats,standard_timebase);
@@ -173,6 +181,23 @@ void* thread_stream_from_file(void *vargp)
             }
         }
 
+        if(resendMediaInfoIntervalSec > 0
+            && (packet.flags & AV_PKT_FLAG_KEY)
+            && nextSentMediaInfoTime < av_gettime_relative())
+        {
+            LOGGER0(CATEGORY_RECEIVER,AV_LOG_WARNING,"sending mediainfo");
+            if (KMP_send_mediainfo(&kmp,&extra)<0) {
+                LOGGER0(CATEGORY_RECEIVER,AV_LOG_FATAL,"couldn't send mediainfo!");
+                break;
+            }
+
+            if (KMP_read_ack(&kmp,&frame_id_ack)) {
+                LOGGER(CATEGORY_RECEIVER,AV_LOG_DEBUG,"received ack for packet id  %lld",frame_id_ack);
+            }
+
+            nextSentMediaInfoTime = av_gettime_relative() + resendMediaInfoInterval;
+        }
+
         lastDts=packet.dts;
 
         samples_stats_add(&stats,packet.dts,packet.pos,packet.size);
@@ -188,20 +213,21 @@ void* thread_stream_from_file(void *vargp)
                rate)*/
 
 
-        uint64_t frame_id_ack;
+
         if (KMP_send_packet(&kmp,&packet)<0) {
             LOGGER0(CATEGORY_RECEIVER,AV_LOG_FATAL,"couldn't send packet!");
             break;
         }
+        frame_id++;
         if (KMP_read_ack(&kmp,&frame_id_ack)) {
             LOGGER(CATEGORY_RECEIVER,AV_LOG_DEBUG,"received ack for packet id  %lld",frame_id_ack);
         }
 
 
-         LOGGER("SENDER",AV_LOG_DEBUG,"sent packet pts=%s dts=%s  size=%d",
+         LOGGER("SENDER",AV_LOG_DEBUG,"sent packet pts=%s dts=%s  size=%d frame_id=%lld frame_id_ack=%lld",
          ts2str(packet.pts,true),
          ts2str(packet.dts,true),
-         packet.size);
+         packet.size, frame_id, frame_id_ack);
 
 
         av_packet_unref(&packet);

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -125,14 +125,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                     _S(KMP_send_ack(&session->kmpClient,&current_position));
                 }
                 break;
-            } else if(!autoAckMode) {
-                received_frame_id++;
-                kmp_frame_position_t media_info_position = { received_frame_id, received_frame_id, 0 };
-                LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for media packet # : %lld",
-                    session->stream_name, media_info_position.frame_id);
-                _S(KMP_send_ack(&session->kmpClient,&media_info_position));
             }
-
          }
         if (header.packet_type==KMP_PACKET_FRAME)
         {

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -121,7 +121,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                     transcode_session_get_ack_frame_id(transcode_session,&current_position);
                     // TODO: we cheat here, received_frame_id may have not been persisted yet
                     // so we should make sure all of the frames are consumed ny upstream
-                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id;
+                    current_position.frame_id = current_position.transcoded_frame_id =  received_frame_id;
                     LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for packet # : %lld",session->stream_name,current_position.frame_id);
                     _S(KMP_send_ack(&session->kmpClient,&current_position));
                 }

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -110,8 +110,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
 
             KMP_log_mediainfo(&session->kmpClient, CATEGORY_RECEIVER, AV_LOG_INFO, newParams);
 
-            if( (retVal = transcode_session_async_set_mediaInfo(transcode_session, newParams)) < 0)
-            {
+            if( (retVal = transcode_session_async_set_mediaInfo(transcode_session, newParams)) < 0) {
                 LOGGER(CATEGORY_RECEIVER,AV_LOG_ERROR,"[%s] transcode_session_async_set_mediaInfo failed",session->stream_name);
 
                 LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] flushing",session->stream_name);
@@ -125,10 +124,16 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                     LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for packet # : %lld",session->stream_name,current_position.frame_id);
                     _S(KMP_send_ack(&session->kmpClient,&current_position));
                 }
-
                 break;
+            } else if(!autoAckMode) {
+                received_frame_id++;
+                kmp_frame_position_t media_info_position = { received_frame_id, received_frame_id, 0 };
+                LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for media packet # : %lld",
+                    session->stream_name, media_info_position.frame_id);
+                _S(KMP_send_ack(&session->kmpClient,&media_info_position));
             }
-        }
+
+         }
         if (header.packet_type==KMP_PACKET_FRAME)
         {
             AVPacket* packet=av_packet_alloc();

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -107,7 +107,8 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                 LOGGER(CATEGORY_RECEIVER,AV_LOG_FATAL,"[%s] Invalid mediainfo",session->stream_name);
                 break;
             }
-            LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] received packet  KMP_PACKET_MEDIA_INFO",session->stream_name);
+
+            KMP_log_mediainfo(transcode_session, CATEGORY_RECEIVER, AV_LOG_INFO, newParams);
 
             if( (retVal = transcode_session_async_set_mediaInfo(transcode_session, newParams)) < 0)
             {

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -121,7 +121,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                     transcode_session_get_ack_frame_id(transcode_session,&current_position);
                     // TODO: we cheat here, received_frame_id may have not been persisted yet
                     // so we should make sure all of the frames are consumed ny upstream
-                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id + 1;
+                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id;
                     LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for packet # : %lld",session->stream_name,current_position.frame_id);
                     _S(KMP_send_ack(&session->kmpClient,&current_position));
                 }

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -108,7 +108,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                 break;
             }
 
-            KMP_log_mediainfo(transcode_session, CATEGORY_RECEIVER, AV_LOG_INFO, newParams);
+            KMP_log_mediainfo(&session->kmpClient, CATEGORY_RECEIVER, AV_LOG_INFO, newParams);
 
             if( (retVal = transcode_session_async_set_mediaInfo(transcode_session, newParams)) < 0)
             {

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -121,7 +121,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                     transcode_session_get_ack_frame_id(transcode_session,&current_position);
                     // TODO: we cheat here, received_frame_id may have not been persisted yet
                     // so we should make sure all of the frames are consumed ny upstream
-                    current_position.frame_id = current_position.transcoded_frame_id =  received_frame_id;
+                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id;
                     LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for packet # : %lld",session->stream_name,current_position.frame_id);
                     _S(KMP_send_ack(&session->kmpClient,&current_position));
                 }

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -121,7 +121,7 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
                     transcode_session_get_ack_frame_id(transcode_session,&current_position);
                     // TODO: we cheat here, received_frame_id may have not been persisted yet
                     // so we should make sure all of the frames are consumed ny upstream
-                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id;
+                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id + 1;
                     LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for packet # : %lld",session->stream_name,current_position.frame_id);
                     _S(KMP_send_ack(&session->kmpClient,&current_position));
                 }

--- a/transcoder/receiver_server.c
+++ b/transcoder/receiver_server.c
@@ -109,7 +109,24 @@ int clientLoop(receiver_server_t *server,receiver_server_session_t *session,tran
             }
             LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] received packet  KMP_PACKET_MEDIA_INFO",session->stream_name);
 
-            transcode_session_async_set_mediaInfo(transcode_session, newParams);
+            if( (retVal = transcode_session_async_set_mediaInfo(transcode_session, newParams)) < 0)
+            {
+                LOGGER(CATEGORY_RECEIVER,AV_LOG_ERROR,"[%s] transcode_session_async_set_mediaInfo failed",session->stream_name);
+
+                LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] flushing",session->stream_name);
+                _S(transcode_session_async_send_packet(transcode_session, NULL));
+
+                if(!autoAckMode) {
+                    transcode_session_get_ack_frame_id(transcode_session,&current_position);
+                    // TODO: we cheat here, received_frame_id may have not been persisted yet
+                    // so we should make sure all of the frames are consumed ny upstream
+                    current_position.frame_id = current_position.transcoded_frame_id = received_frame_id;
+                    LOGGER(CATEGORY_RECEIVER,AV_LOG_INFO,"[%s] sending ack for packet # : %lld",session->stream_name,current_position.frame_id);
+                    _S(KMP_send_ack(&session->kmpClient,&current_position));
+                }
+
+                break;
+            }
         }
         if (header.packet_type==KMP_PACKET_FRAME)
         {

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -123,7 +123,7 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
             if (currentCodecParams->extradata_size>0 &&
                 newCodecParams->extradata!=NULL &&
                 currentCodecParams->extradata!=NULL
-                // FIXME: uncomment memcp!!!
+                // FIXME: uncomment memcmp!!!
                 && ctx->processedStats.totalFrames > 0
                 /*&& 0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size)*/)
                 changed=true;
@@ -137,6 +137,8 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
         } else {
 
             LOGGER0(CATEGORY_TRANSCODING_SESSION,AV_LOG_ERROR,"changing media info on the fly is currently not supported");
+            avcodec_parameters_free(&newMediaInfo->codecParams);
+            av_free(newMediaInfo);
             return -1;
         }
     }

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -120,14 +120,11 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
                 newCodecParams->height!=currentCodecParams->height ||
                 newCodecParams->extradata_size!=currentCodecParams->extradata_size;
 
-            if (currentCodecParams->extradata_size>0 &&
-                newCodecParams->extradata!=NULL &&
-                currentCodecParams->extradata!=NULL
-                // FIXME: uncomment memcmp!!!
-                && ctx->processedStats.totalFrames > 0
-                /*&& 0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size)*/)
-                changed=true;
-        }
+        if (currentCodecParams->extradata_size>0 &&
+            newCodecParams->extradata!=NULL &&
+            currentCodecParams->extradata!=NULL &&
+            0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size))
+            changed=true;
 
         if (!changed) {
 

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -112,18 +112,21 @@ void transcode_session_get_ack_frame_id(transcode_session_t *ctx,kmp_frame_posit
 int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInfo_t* newMediaInfo)
 {
     if (ctx->currentMediaInfo) {
-        AVCodecParameters *currentCodecParams=ctx->currentMediaInfo->codecParams;
-        AVCodecParameters *newCodecParams=newMediaInfo->codecParams;
-        bool changed=newCodecParams->width!=currentCodecParams->width ||
-            newCodecParams->height!=currentCodecParams->height ||
-            newCodecParams->extradata_size!=currentCodecParams->extradata_size;
+        bool changed = false;
+        if(ctx->currentMediaInfo != newMediaInfo) {
+            AVCodecParameters *currentCodecParams=ctx->currentMediaInfo->codecParams;
+            AVCodecParameters *newCodecParams=newMediaInfo->codecParams;
+            changed=newCodecParams->width!=currentCodecParams->width ||
+                newCodecParams->height!=currentCodecParams->height ||
+                newCodecParams->extradata_size!=currentCodecParams->extradata_size;
 
-        if (currentCodecParams->extradata_size>0 &&
-            newCodecParams->extradata!=NULL &&
-            currentCodecParams->extradata!=NULL
-            // FIXME: uncomment memcp!!!
-            /*&& 0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size)*/)
-            changed=true;
+            if (currentCodecParams->extradata_size>0 &&
+                newCodecParams->extradata!=NULL &&
+                currentCodecParams->extradata!=NULL
+                // FIXME: uncomment memcp!!!
+                /*&& 0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size)*/)
+                changed=true;
+        }
 
         if (!changed) {
 

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -124,6 +124,7 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
                 newCodecParams->extradata!=NULL &&
                 currentCodecParams->extradata!=NULL
                 // FIXME: uncomment memcp!!!
+                && ctx->processedStats.totalFrames > 0
                 /*&& 0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size)*/)
                 changed=true;
         }

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -112,13 +112,11 @@ void transcode_session_get_ack_frame_id(transcode_session_t *ctx,kmp_frame_posit
 int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInfo_t* newMediaInfo)
 {
     if (ctx->currentMediaInfo) {
-        bool changed = false;
-        if(ctx->currentMediaInfo != newMediaInfo) {
-            AVCodecParameters *currentCodecParams=ctx->currentMediaInfo->codecParams;
-            AVCodecParameters *newCodecParams=newMediaInfo->codecParams;
-            changed=newCodecParams->width!=currentCodecParams->width ||
-                newCodecParams->height!=currentCodecParams->height ||
-                newCodecParams->extradata_size!=currentCodecParams->extradata_size;
+        AVCodecParameters *currentCodecParams=ctx->currentMediaInfo->codecParams;
+        AVCodecParameters *newCodecParams=newMediaInfo->codecParams;
+        bool changed=newCodecParams->width!=currentCodecParams->width ||
+            newCodecParams->height!=currentCodecParams->height ||
+            newCodecParams->extradata_size!=currentCodecParams->extradata_size;
 
         if (currentCodecParams->extradata_size>0 &&
             newCodecParams->extradata!=NULL &&
@@ -126,16 +124,14 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
             0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size))
             changed=true;
 
-        if (!changed) {
+        avcodec_parameters_free(&newMediaInfo->codecParams);
+        av_free(newMediaInfo);
 
-            avcodec_parameters_free(&newMediaInfo->codecParams);
-            av_free(newMediaInfo);
+        if (!changed) {
+            LOGGER0(CATEGORY_TRANSCODING_SESSION,AV_LOG_INFO,"transcode_session_set_media_info. media info did not change");
             return 0;
         } else {
-
-            LOGGER0(CATEGORY_TRANSCODING_SESSION,AV_LOG_ERROR,"changing media info on the fly is currently not supported");
-            avcodec_parameters_free(&newMediaInfo->codecParams);
-            av_free(newMediaInfo);
+            LOGGER0(CATEGORY_TRANSCODING_SESSION,AV_LOG_ERROR,"transcode_session_set_media_info, changing media info on the fly is currently not supported");
             return -1;
         }
     }

--- a/transcoder/transcode/transcode_session.c
+++ b/transcoder/transcode/transcode_session.c
@@ -85,8 +85,7 @@ int transcode_session_async_set_mediaInfo(transcode_session_t *ctx,transcode_med
         return transcode_session_set_media_info(ctx,mediaInfo);
     }
     LOGGER(CATEGORY_TRANSCODING_SESSION,AV_LOG_DEBUG,"[%s] enqueue media info",ctx->name);
-    packet_queue_write_mediaInfo(&ctx->packetQueue, mediaInfo);
-    return 0;
+    return packet_queue_write_mediaInfo(&ctx->packetQueue, mediaInfo);
 }
 
 int transcode_session_async_send_packet(transcode_session_t *ctx, struct AVPacket* packet)
@@ -121,8 +120,9 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
 
         if (currentCodecParams->extradata_size>0 &&
             newCodecParams->extradata!=NULL &&
-            currentCodecParams->extradata!=NULL &&
-            0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size))
+            currentCodecParams->extradata!=NULL
+            // FIXME: uncomment memcp!!!
+            /*&& 0!=memcmp(newCodecParams->extradata,currentCodecParams->extradata,currentCodecParams->extradata_size)*/)
             changed=true;
 
         if (!changed) {
@@ -130,6 +130,10 @@ int transcode_session_set_media_info(transcode_session_t *ctx,transcode_mediaInf
             avcodec_parameters_free(&newMediaInfo->codecParams);
             av_free(newMediaInfo);
             return 0;
+        } else {
+
+            LOGGER0(CATEGORY_TRANSCODING_SESSION,AV_LOG_ERROR,"changing media info on the fly is currently not supported");
+            return -1;
         }
     }
 

--- a/transcoder/transcode/transcode_session_output.c
+++ b/transcoder/transcode/transcode_session_output.c
@@ -130,8 +130,17 @@ int transcode_session_output_send_output_packet(transcode_session_output_t *pOut
         }
         av_write_frame(pOutput->oc, NULL);
 
-        av_packet_free(&cpPacket);
+        ack_desc_t desc = {0};
+        if( (ret = get_packet_frame_id(cpPacket,&desc.id)) >= 0) {
+            if(pOutput->acker.ctx){
+                 pOutput->acker.map(&pOutput->acker,desc.id,&desc);
+             }
+            pOutput->lastMappedAck = desc.id;
+            pOutput->lastAck=desc.id;
+            pOutput->lastOffset=desc.offset;
+        }
 
+        av_packet_free(&cpPacket);
     }
 
     if (pOutput->sender!=NULL)


### PR DESCRIPTION
**issue:**
transcoder as a micro-service does not handle codec changes.
therefore, transcoding fails once codec change is detected (KMP_MEDIA_INFO_PACKET is received).
This cause stream to stuck since downstream KMP node would not get last ack
until segmenter sends one, and segmenter won't send one until specific segment is ready to be persisted.
In the meanwhile, transcoder gets re-created and old media info segment is re-played over and over again, causing waste of system resources, keeping transcoder fail over and over again.

**solution**

   The quick and dirty fix is to for transcoder recognize the need to skip over last media info segment and send an ack downstream without waiting for segmenter, which will resolve the issue immediately.
  Once the last segment is confirmed, transcoder starts with new segment after a single restart.

**downsides**

while this solves the issue we no more have control over remaining segment since we give up on the rest of segment in favor of new segment (**segment** means here collection of frames using same media info).

 